### PR TITLE
Fix/add destroy hook

### DIFF
--- a/ophyd_devices/interfaces/base_classes/psi_device_base.py
+++ b/ophyd_devices/interfaces/base_classes/psi_device_base.py
@@ -156,6 +156,11 @@ class PSIDeviceBase(Device):
         self.stopped = True  # Set stopped flag to True, in case a custom stop method listens to stopped property
         super().stop(success=success)
 
+    def destroy(self):
+        """Destroy the device."""
+        self.on_destroy()  # Call the on_destroy method
+        return super().destroy()
+
     ########################################
     # Utility Method to wait for signals   #
     ########################################
@@ -234,3 +239,6 @@ class PSIDeviceBase(Device):
 
     def on_stop(self) -> None:
         """Called when the device is stopped."""
+
+    def on_destroy(self) -> None:
+        """Called when the device is destroyed. Cleanup resources here."""

--- a/tests/test_psi_device_base.py
+++ b/tests/test_psi_device_base.py
@@ -89,6 +89,15 @@ def test_on_stage_hook(device):
         mock_on_stage.assert_called_once()
 
 
+def test_on_destroy_hook(device):
+    """Test on destroy hook"""
+    assert device.destroyed is False
+    with mock.patch.object(device, "on_destroy") as mock_on_destroy:
+        device.destroy()
+        mock_on_destroy.assert_called_once()
+        assert device.destroyed is True
+
+
 def test_on_unstage_hook(device):
     """Test user method hooks"""
     with mock.patch.object(device, "on_unstage") as mock_on_unstage:


### PR DESCRIPTION
This PR adds an on_destroy hook to ophyd's destroy method for the PSIDeviceBase class.