### PR TITLE
fix: restrict pyepics version until ophyd is fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "numpy >= 1.24, <3.0",
     "pyyaml ~= 6.0",
     "std_daq_client ~= 1.3",
-    "pyepics ~= 3.5, >=3.5.5",
+    "pyepics >=3.5.5, <=3.5.7",
     "pytest ~= 8.0",
     "h5py ~= 3.10",
     "hdf5plugin >=4.3, < 6.0",


### PR DESCRIPTION
ophyd is currently incompatible with the latest pyepics release. For now, let's just fix the pyepics version