### PR TITLE
Fix Falcon dxp trigger signals

### DIFF
--- a/ophyd_devices/devices/dxp.py
+++ b/ophyd_devices/devices/dxp.py
@@ -158,7 +158,7 @@ class EpicsDXPFalconMultiElementSystem(EpicsDXPBaseSystem):
     # Acquisition control
     erase_all = Cpt(EpicsSignal, "EraseAll")
     erase_start = Cpt(EpicsSignal, "EraseStart", put_complete=True, trigger_value=1)
-    start_all = Cpt(EpicsSignal, "StartAll", put_complete=True, trigger_value=1)
+    start_all = Cpt(EpicsSignal, "StartAll", put_complete=True)
     stop_all = Cpt(EpicsSignal, "StopAll")
 
     # Status
@@ -231,7 +231,7 @@ class EpicsDXPMultiElementSystem(_EpicsDXPMultiElementSystem):
     # Override some action signals, so calling `set`` method
     # returns a waitable Status object. Otherwise the Status object is immediately done.
     erase_start = Cpt(EpicsSignal, "EraseStart", put_complete=True, trigger_value=1)
-    start_all = Cpt(EpicsSignal, "StartAll", put_complete=True, trigger_value=1)
+    start_all = Cpt(EpicsSignal, "StartAll", put_complete=True)
 
     # mca.EpicsDXPMultiElementSystem maps the EPICS records under wrong names, i.e.
     # copy_adcp_ercent_rule, copy_roic_hannel and copy_roie_nergy

--- a/tests/test_dxp/test_dxp.py
+++ b/tests/test_dxp/test_dxp.py
@@ -130,3 +130,15 @@ def test_mercury(mock_mercury):
     assert isinstance(mock_mercury, EpicsDXPMultiElementSystem)
     # assert isinstance(mock_mercury, EpicsDXPMapping) # Not sure why this fails
     assert isinstance(mock_mercury, ADBase)
+
+
+def test_xmap_trigger(mock_xmap):
+    """Test the xMAP device trigger method."""
+    mock_xmap: xMAP
+    mock_xmap.erase_start.put(0)
+    assert mock_xmap.erase_start.get() == 0
+    status = mock_xmap.trigger()
+    # Tagged trigger value, should be set to 1 when trigger is called
+    assert mock_xmap.erase_start.get() == 1
+    assert status.success is True
+    assert status.done is True

--- a/tests/test_dxp/test_dxp.py
+++ b/tests/test_dxp/test_dxp.py
@@ -99,6 +99,18 @@ def test_falcon(mock_falcon):
     ]
 
 
+def test_falcon_trigger(mock_falcon):
+    """Test the Falcon device trigger method."""
+    mock_falcon: TestFalcon
+    mock_falcon.erase_start.put(0)
+    assert mock_falcon.erase_start.get() == 0
+    status = mock_falcon.trigger()
+    # Tagged trigger value, should be set to 1 when trigger is called
+    assert mock_falcon.erase_start.get() == 1
+    assert status.success is True
+    assert status.done is True
+
+
 def test_xmap(mock_xmap):
     """Test the xMAP device."""
     # Test the default values


### PR DESCRIPTION
Ophyd.device only supports a single trigger signal (https://github.com/bluesky/ophyd/blob/main/ophyd/device.py#L1525). However, the implementation of `EpicsDXPFalconMultiElementSystem` implements two signals. THis PR removes the tag for start_all, an keeps erase_start consistent with `EpicsDXPBaseSystem`