### PR TITLE
make SimulatedDataMonitor deal with inf and nan

### DIFF
--- a/ophyd_devices/sim/sim_data.py
+++ b/ophyd_devices/sim/sim_data.py
@@ -6,6 +6,7 @@ import time as ttime
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from copy import deepcopy
+from math import copysign, isinf, isnan
 
 import numpy as np
 from bec_lib import bec_logger
@@ -70,6 +71,14 @@ DEFAULT_PARAMS_HOT_PIXEL = {
     "hot_pixel_types": [HotPixelType.FLUCTUATING, HotPixelType.CONSTANT, HotPixelType.FLUCTUATING],
     "hot_pixel_values": np.array([1e3, 1e4, 1e3]),
 }
+
+
+def _safeint(val: float) -> int:
+    if isnan(val):
+        return 0
+    if isinf(val):
+        return int(copysign(2_147_483_647, val))
+    return int(val)
 
 
 class SimulatedDataBase(ABC):
@@ -429,7 +438,7 @@ class SimulatedDataMonitor(SimulatedDataBase):
         else:
             motor_pos = 0
         method = self._model
-        value = int(method.eval(params=self._model_params, x=motor_pos))
+        value = _safeint(method.eval(params=self._model_params, x=motor_pos))
         return self._add_noise(value, self.params["noise"], self.params["noise_multiplier"])
 
     def _add_noise(self, v: int, noise: NoiseType, noise_multiplier: float) -> int:

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -24,6 +24,7 @@ from ophyd_devices.interfaces.protocols.bec_protocols import (
     BECSignalProtocol,
 )
 from ophyd_devices.sim.sim_camera import SimCamera
+from ophyd_devices.sim.sim_data import _safeint
 from ophyd_devices.sim.sim_flyer import SimFlyer
 from ophyd_devices.sim.sim_frameworks.h5_image_replay_proxy import H5ImageReplayProxy
 from ophyd_devices.sim.sim_frameworks.slit_proxy import SlitProxy
@@ -233,7 +234,7 @@ def test_monitor_readback(monitor, center):
         elif "center" in monitor.sim.params:
             monitor.sim.params["center"] = center
         assert isinstance(monitor.read()[monitor.name]["value"], monitor.BIT_DEPTH)
-        expected_value = monitor.sim._model.eval(monitor.sim._model_params, x=motor_pos)
+        expected_value = _safeint(monitor.sim._model.eval(monitor.sim._model_params, x=motor_pos))
         print(expected_value, monitor.read()[monitor.name]["value"])
         tolerance = (
             monitor.sim.params["noise_multipler"] + 1


### PR DESCRIPTION
The tests `test_simulation.py::test_monitor_readback` broke because some experiment params gave `inf` results through an `lmfit` model and couldn't be coerced to `int`.

To make it safe to test all models like this, this PR modifies `SimulatedDataMonitor._compute` to handle `inf` and `nan` model results.