### PR TITLE
fix(undulator): Remove raise for undulator if operator controlled

### DIFF
--- a/ophyd_devices/devices/areadetector/cam.py
+++ b/ophyd_devices/devices/areadetector/cam.py
@@ -274,6 +274,10 @@ class ASItpxCam(CamBase):
 
     """
 
+    acquire = ADCpt(EpicsSignal, "Acquire")
+    acquire_busy = ADCpt(EpicsSignalRO, "AcquireBusy")
+    detector_state = ADCpt(EpicsSignalRO, "DetectorState_RBV")
+
     tdc1_enable = ADCpt(EpicsSignalWithRBV, "TDC1Enable")
     tdc1_edge = ADCpt(EpicsSignalWithRBV, "TDC1Edge")
     tdc1_output = ADCpt(EpicsSignalWithRBV, "TDC1Output")
@@ -282,6 +286,7 @@ class ASItpxCam(CamBase):
     tdc2_output = ADCpt(EpicsSignalWithRBV, "TDC2Output")
 
     trigger_source = ADCpt(EpicsSignalWithRBV, "TriggerSource")
+    trigger_mode = ADCpt(EpicsSignalWithRBV, "TriggerMode")
     trigger_polarity = ADCpt(EpicsSignalWithRBV, "TriggerPolarity")
     trigger_delay = ADCpt(EpicsSignalWithRBV, "TriggerDelay")
     exposure_mode = ADCpt(EpicsSignalWithRBV, "ExposureMode")

--- a/ophyd_devices/devices/undulator.py
+++ b/ophyd_devices/devices/undulator.py
@@ -24,7 +24,7 @@ class UNDULATORCONTROL(int, enum.Enum):
     BEAMLINE = 1
 
 
-class UndulatorEpicsSignal(EpicsSignal):
+class UndulatorSetointSignal(EpicsSignal):
     """
     SLS Undulator setpoint control
     """
@@ -45,10 +45,42 @@ class UndulatorEpicsSignal(EpicsSignal):
         If the undulator is operator controlled, it will not move.
         """
         if self.parent.select_control.get() == UNDULATORCONTROL.OPERATOR.value:
+            raise PermissionError("Undulator is operator controlled!")
+        return super().put(
+            value,
+            force=force,
+            connection_timeout=connection_timeout,
+            callback=callback,
+            use_complete=use_complete,
+            timeout=timeout,
+            **kwargs,
+        )
+
+
+class UndulatorStopSignal(EpicsSignal):
+    """
+    SLS Undulator stop signal"""
+
+    def put(
+        self,
+        value,
+        force=False,
+        connection_timeout=DEFAULT_CONNECTION_TIMEOUT,
+        callback=None,
+        use_complete=None,
+        timeout=DEFAULT_WRITE_TIMEOUT,
+        **kwargs,
+    ):
+        """
+        Put a value to the setpoint PV.
+
+        If the undulator is operator controlled, it will not move.
+        """
+        if self.parent.select_control.get() == UNDULATORCONTROL.OPERATOR.value:
             logger.error(
                 f"Cannot use put for signal {self.name}; Undulator is operator controlled!"
             )
-            return  # Do not raise an error, just log it and return None.
+            return None
         return super().put(
             value,
             force=force,
@@ -65,10 +97,10 @@ class UndulatorGap(PVPositioner):
     SLS Undulator gap control
     """
 
-    setpoint = Cpt(UndulatorEpicsSignal, suffix="GAP-SP")
-    readback = Cpt(EpicsSignal, suffix="GAP-RBV", kind="hinted", auto_monitor=True)
+    setpoint = Cpt(UndulatorSetointSignal, suffix="GAP-SP")
+    readback = Cpt(EpicsSignalRO, suffix="GAP-RBV", kind="hinted", auto_monitor=True)
 
-    stop_signal = Cpt(UndulatorEpicsSignal, suffix="STOP")
+    stop_signal = Cpt(UndulatorStopSignal, suffix="STOP")
     done = Cpt(EpicsSignalRO, suffix="DONE", auto_monitor=True)
 
     select_control = Cpt(EpicsSignalRO, suffix="SCTRL", auto_monitor=True)

--- a/ophyd_devices/devices/undulator.py
+++ b/ophyd_devices/devices/undulator.py
@@ -45,9 +45,10 @@ class UndulatorEpicsSignal(EpicsSignal):
         If the undulator is operator controlled, it will not move.
         """
         if self.parent.select_control.get() == UNDULATORCONTROL.OPERATOR.value:
-            raise PermissionError(
+            logger.error(
                 f"Cannot use put for signal {self.name}; Undulator is operator controlled!"
             )
+            return  # Do not raise an error, just log it and return None.
         return super().put(
             value,
             force=force,

--- a/ophyd_devices/devices/undulator.py
+++ b/ophyd_devices/devices/undulator.py
@@ -77,9 +77,6 @@ class UndulatorStopSignal(EpicsSignal):
         If the undulator is operator controlled, it will not move.
         """
         if self.parent.select_control.get() == UNDULATORCONTROL.OPERATOR.value:
-            logger.error(
-                f"Cannot use put for signal {self.name}; Undulator is operator controlled!"
-            )
             return None
         return super().put(
             value,

--- a/tests/test_undulator.py
+++ b/tests/test_undulator.py
@@ -56,7 +56,11 @@ def test_undulator_raises_when_disabled(mock_undulator):
 
 def test_undulator_stop_call(mock_undulator):
     mock_undulator.select_control._read_pv.mock_data = 1
+    mock_undulator.stop_signal.put(0)
     mock_undulator.stop()
+    assert mock_undulator.stop_signal.get() == 1
+    mock_undulator.stop_signal.put(0)
     mock_undulator.select_control._read_pv.mock_data = 0
-    with pytest.raises(PermissionError) as e:
-        mock_undulator.stop()
+    # Error should just be logged, not raised.
+    mock_undulator.stop()
+    assert mock_undulator.stop_signal.get() == 0


### PR DESCRIPTION
The undulator signals should not raise a Permission error if called when the device is operator controlled. While raising is valid for the 'move', we should not raise on every 'stop' call. The alternative would be to make the device read_only once its operator controlled, however, I believe this solution to be more pragmatic and easier in real case scenarios. (Any calls to the protected PV is logged).