### PR TITLE
fix: only connect if specified

### DIFF
--- a/ophyd_devices/utils/static_device_test.py
+++ b/ophyd_devices/utils/static_device_test.py
@@ -202,7 +202,7 @@ class StaticDeviceTest:
         assert isinstance(obj.describe_configuration(), dict)
         assert isinstance(obj.hints, dict)
 
-    def validate_schema(self, name: str, conf: dict) -> None:
+    def validate_schema(self, name: str, conf: dict) -> int:
         """
         Validate the device config against the BEC device model
 
@@ -312,13 +312,10 @@ class StaticDeviceTest:
                 try:
                     return_val += self.validate_schema(name, conf)
                     return_val += self.check_device_classes(name, conf)
-                    if connect:
+                    if connect and device_manager is not None:
                         return_val += self.connect_device(name, conf)
                     self.validate_schema(name, conf)
                     self.check_device_classes(name, conf)
-                    if device_manager is not None:
-                        self.connect_device(name, conf)
-
                     if return_val == 0:
                         status = True
                         self.print_and_write(f"{name} is OK")


### PR DESCRIPTION
if the test config doesn't specify connect=True, don't connect to the device