### PR TITLE
Add motor movement callback to SimMonitor

### DIFF
--- a/ophyd_devices/sim/sim_data.py
+++ b/ophyd_devices/sim/sim_data.py
@@ -164,6 +164,10 @@ class SimulatedDataBase(ABC):
         """
         Method to set the parameters for the active simulation model.
         """
+        self._set_params(params)
+
+    def _set_params(self, params: dict) -> None:
+        """Utility method to set parameters for active model."""
         for k, v in params.items():
             if k in self.params:
                 if k == "noise":
@@ -327,6 +331,32 @@ class SimulatedDataMonitor(SimulatedDataBase):
         self.bit_depth = self.parent.BIT_DEPTH
         self._init_default()
 
+    @SimulatedDataBase.params.setter
+    def params(self, params: dict) -> None:
+        SimulatedDataBase.params.fset(self, params)
+        self._add_callback_to_motor()
+
+    def _add_callback_to_motor(self) -> None:
+        # Setup subscription to the reference motor if available
+        mot_name = self.params.get("ref_motor", "")
+        if not hasattr(self.parent, "device_manager"):
+            return
+        if mot_name in self.parent.device_manager.devices:
+            if hasattr(self.parent, "setup_readback_monitor"):
+                self.parent.setup_readback_monitor(mot_name)
+
+    def select_model(self, model: str) -> None:
+        """
+        Method to select the active simulation model.
+        It will initiate the model_cls and parameters for the model.
+
+        Args:
+            model (str): Name of the simulation model to select.
+
+        """
+        super().select_model(model)
+        self._add_callback_to_motor()
+
     def _get_additional_params(self) -> None:
         params = deepcopy(DEFAULT_PARAMS_NOISE)
         params.update(deepcopy(DEFAULT_PARAMS_MOTOR))
@@ -432,7 +462,7 @@ class SimulatedDataMonitor(SimulatedDataBase):
         Returns:
             float: Value computed by the active model.
         """
-        mot_name = self.params["ref_motor"]
+        mot_name = self.params.get("ref_motor", "")
         if self.parent.device_manager and mot_name in self.parent.device_manager.devices:
             motor_pos = self.parent.device_manager.devices[mot_name].obj.read()[mot_name]["value"]
         else:

--- a/ophyd_devices/sim/sim_data.py
+++ b/ophyd_devices/sim/sim_data.py
@@ -108,7 +108,7 @@ class SimulatedDataBase(ABC):
         self.parent = parent
         self.sim_state = defaultdict(dict)
         self.registered_proxies = getattr(self.parent, "registered_proxies", {})
-        self._model = {}
+        self._model = None
         self._model_params = None
         self._params = {}
 
@@ -329,6 +329,7 @@ class SimulatedDataMonitor(SimulatedDataBase):
         self._model_lookup = self.init_lmfit_models()
         super().__init__(*args, parent=parent, **kwargs)
         self.bit_depth = self.parent.BIT_DEPTH
+        self._cb_registered = False
         self._init_default()
 
     @SimulatedDataBase.params.setter
@@ -341,9 +342,22 @@ class SimulatedDataMonitor(SimulatedDataBase):
         mot_name = self.params.get("ref_motor", "")
         if not hasattr(self.parent, "device_manager"):
             return
+        if not hasattr(self.parent.device_manager, "devices"):
+            return
         if mot_name in self.parent.device_manager.devices:
             if hasattr(self.parent, "setup_readback_monitor"):
                 self.parent.setup_readback_monitor(mot_name)
+            # pylint: disable=protected-access
+            if (
+                hasattr(self.parent, "_registered_callback")
+                and self.parent._registered_callback is not None
+                and self.parent._registered_callback.motor == mot_name
+            ):
+                # If the callback was registered, keep track of it
+                self._cb_registered = True
+            else:
+                # If no callback was registered, this should also be reflected in self._cb_registered
+                self._cb_registered = False
 
     def select_model(self, model: str) -> None:
         """
@@ -396,6 +410,8 @@ class SimulatedDataMonitor(SimulatedDataBase):
             dict: {name: value} for the active simulation model.
         """
         rtr = {}
+        if not isinstance(self._model, Model):
+            return rtr
         params = self._model.make_params()
         for name, parameter in params.items():
             if name in DEFAULT_PARAMS_LMFIT:
@@ -465,6 +481,10 @@ class SimulatedDataMonitor(SimulatedDataBase):
         mot_name = self.params.get("ref_motor", "")
         if self.parent.device_manager and mot_name in self.parent.device_manager.devices:
             motor_pos = self.parent.device_manager.devices[mot_name].obj.read()[mot_name]["value"]
+            # It can happen that the SimMonitor was created before the motor was available in the device manager,
+            # therefore we have to check if a callback is registered and update it if not.
+            if not self._cb_registered:
+                self._add_callback_to_motor()
         else:
             motor_pos = 0
         method = self._model

--- a/ophyd_devices/sim/sim_monitor.py
+++ b/ophyd_devices/sim/sim_monitor.py
@@ -1,5 +1,7 @@
 """Module for simulated monitor devices."""
 
+from dataclasses import dataclass
+
 import numpy as np
 from bec_lib import messages
 from bec_lib.endpoints import MessageEndpoints
@@ -13,6 +15,13 @@ from ophyd_devices.sim.sim_signals import ReadOnlySignal, SetableSignal
 from ophyd_devices.utils import bec_utils
 
 logger = bec_logger.logger
+
+
+@dataclass
+class RegisteredCallback:
+
+    motor: str
+    callback_id: int
 
 
 class SimMonitor(ReadOnlySignal):
@@ -61,8 +70,9 @@ class SimMonitor(ReadOnlySignal):
         self.precision = precision
         self.sim_init = sim_init
         self.device_manager = device_manager
-        self.sim = self.sim_cls(parent=self, **kwargs)
         self._registered_proxies = {}
+        self._registered_callback: RegisteredCallback | None = None
+        self.sim = self.sim_cls(parent=self, **kwargs)
 
         super().__init__(
             name=name,
@@ -77,9 +87,36 @@ class SimMonitor(ReadOnlySignal):
             self.sim.set_init(self.sim_init)
 
     @property
-    def registered_proxies(self) -> None:
+    def registered_proxies(self) -> dict:
         """Dictionary of registered signal_names and proxies."""
         return self._registered_proxies
+
+    def setup_readback_monitor(self, motor_name: str) -> None:
+        """
+        Set up monitoring of the readback signal of a motor.
+
+        Args:
+            motor_name (str): The name of the motor to monitor.
+        """
+
+        if self._registered_callback:
+            if self._registered_callback.motor == motor_name:
+                # Already registered callback
+                return
+            else:  # Unregister callback from previous motor if necessary
+                motor = self.device_manager.devices.get(self._registered_callback.motor, None)
+                if motor:
+                    motor.unsubscribe(self._registered_callback.callback_id)
+
+        # Register new callback
+        motor = self.device_manager.devices.get(motor_name, None)
+        if motor:
+            cb_id = motor.subscribe(self._update_readback, run=True)
+            self._registered_callback = RegisteredCallback(motor=motor_name, callback_id=cb_id)
+
+    def _update_readback(self, value, **kwargs):
+        """Callback function to update the readback value."""
+        self.get()  # Trigger a read to update the readback value
 
 
 class SimMonitorAsyncControl(Device):

--- a/ophyd_devices/sim/sim_positioner.py
+++ b/ophyd_devices/sim/sim_positioner.py
@@ -85,6 +85,7 @@ class SimPositioner(Device, PositionerBase):
         self.precision = precision
         self.sim_init = sim_init
         self._registered_proxies = {}
+        self._lock = threading.RLock()
 
         self.update_frequency = update_frequency
         self._stopped = False
@@ -186,21 +187,25 @@ class SimPositioner(Device, PositionerBase):
                     raise DeviceStopError(f"{self.name} was stopped")
                 ttime.sleep(1 / self.update_frequency)
             self._update_state(self.readback.get())
-            for status in self._status_list:
-                status.set_finished()
         # pylint: disable=broad-except
         except Exception as exc:
             content = traceback.format_exc()
             logger.warning(
-                f"Error in on_complete call in device {self.name}. Error traceback: {content}"
+                f"Error in _move_to_setpoint call in device {self.name}. Error traceback: {content}"
             )
-            for status in self._status_list:
-                status.set_exception(exc=exc)
+            with self._lock:
+                for status in self._status_list:
+                    status.set_exception(exc=exc)
+                self._status_list = []
         finally:
-            self.motor_is_moving.put(0)
-            if not self._stopped:
-                self._update_state(self.readback.get())
-            self._status_list = []
+            with self._lock:
+                self.motor_is_moving.put(0)
+                if not self._stopped:
+                    self._update_state(self.readback.get())
+                for status in self._status_list:
+                    if not status.done:
+                        status.set_finished()
+                self._status_list = []
 
     def move(self, value: float, **kwargs) -> DeviceStatus:
         """Change the setpoint of the simulated device, and simultaneously initiate a motion."""
@@ -210,7 +215,8 @@ class SimPositioner(Device, PositionerBase):
         self.setpoint.put(value)
 
         st = DeviceStatus(device=self)
-        self._status_list.append(st)
+        with self._lock:
+            self._status_list.append(st)
         if self.delay:
             if self.move_thread is None or not self.move_thread.is_alive():
                 self.move_thread = threading.Thread(target=self._move_to_setpoint)

--- a/ophyd_devices/sim/sim_signals.py
+++ b/ophyd_devices/sim/sim_signals.py
@@ -80,7 +80,8 @@ class SetableSignal(Signal):
         """
         old_value = self._readback
         self._readback = self._value = self._get_value()
-        self._run_subs(sub_type=self.SUB_VALUE, old_value=old_value, value=self._readback)
+        if old_value != self._readback:  # only run subs if the value has changed
+            self._run_subs(sub_type=self.SUB_VALUE, old_value=old_value, value=self._readback)
         return self._readback
 
     # pylint: disable=arguments-differ
@@ -89,9 +90,11 @@ class SetableSignal(Signal):
 
         Core function for signal.
         """
+        old_value = self._value
         self.check_value(value)
         self._update_sim_state(value)
         self._value = value
+        self._run_subs(sub_type=self.SUB_VALUE, old_value=old_value, value=self._value)
         super().put(value)
 
     def set(self, value):

--- a/ophyd_devices/sim/sim_waveform.py
+++ b/ophyd_devices/sim/sim_waveform.py
@@ -129,9 +129,9 @@ class SimWaveform(Device):
         self._trigger_received = 0
         self.scan_info = scan_info
         self._delay_slice_update = False
+        self._slice_index = 0
         if self.sim_init:
             self.sim.set_init(self.sim_init)
-        self._slice_index = 0
 
     @property
     def delay_slice_update(self) -> bool:

--- a/ophyd_devices/utils/static_device_test.py
+++ b/ophyd_devices/utils/static_device_test.py
@@ -286,7 +286,7 @@ class StaticDeviceTest:
             if device_manager is not None:  # Only possible if bec-server is installed
                 obj = self.construct_device_obj(name, conf)
                 if obj is None:  # construction failed, skip connection test
-                    return_value += 1
+                    return_val += 1
                 elif obj is not None and connect:
                     return_val += self.connect_device(
                         name,

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -221,10 +221,12 @@ def test_init_async_monitor(async_monitor):
 
 
 @pytest.mark.parametrize("center", [-10, 0, 10])
-def test_monitor_readback(monitor, center):
+def test_monitor_readback(monitor, center, positioner):
     """Test the readback method of SimMonitor."""
     motor_pos = 0
-    monitor.device_manager.add_device(name="samx", value=motor_pos)
+    samx = SimPositioner(name="samx", device_manager=monitor.device_manager)
+    setattr(samx, "obj", samx)  # Set obj attribute to itself for proxy lookup
+    monitor.device_manager.devices["samx"] = samx
     for model_name in monitor.sim.get_models():
         monitor.sim.select_model(model_name)
         monitor.sim.params["noise_multipler"] = 10
@@ -234,16 +236,28 @@ def test_monitor_readback(monitor, center):
         elif "center" in monitor.sim.params:
             monitor.sim.params["center"] = center
         assert isinstance(monitor.read()[monitor.name]["value"], monitor.BIT_DEPTH)
-        expected_value = _safeint(monitor.sim._model.eval(monitor.sim._model_params, x=motor_pos))
-        print(expected_value, monitor.read()[monitor.name]["value"])
+        expected_value = _safeint(
+            monitor.sim._model.eval(monitor.sim._model_params, x=samx.read()["samx"]["value"])
+        )
         tolerance = (
             monitor.sim.params["noise_multipler"] + 1
         )  # due to ceiling in calculation, but maximum +1int
         assert np.isclose(
             monitor.read()[monitor.name]["value"],
             expected_value,
-            atol=monitor.sim.params["noise_multipler"] + 1,
+            atol=monitor.sim.params["noise_multipler"] + 2,  # allow extra tolerance for ceiling
         )
+
+    # Test callback on motor motion
+    _callback_bucket = []
+
+    def _callback(value, **kwargs):
+        _callback_bucket.append(value)
+
+    monitor.subscribe(_callback, run=False)
+    assert not _callback_bucket
+    monitor.device_manager.devices["samx"].move(10).wait()
+    assert len(_callback_bucket) > 0
 
 
 @pytest.mark.parametrize("amplitude, noise_multiplier", [(0, 1), (100, 10), (1000, 50)])

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -48,6 +48,7 @@ def waveform(name="waveform"):
     """Fixture for SimWaveform."""
     dm = DMMock()
     wave = SimWaveform(name=name, device_manager=dm)
+    wave.wait_for_connection()
     yield wave
 
 
@@ -59,10 +60,21 @@ def signal(name="signal"):
 
 
 @pytest.fixture(scope="function")
-def monitor(name="monitor"):
-    """Fixture for SimMonitor."""
+def samx(name="samx"):
+    """Fixture for SimPositioner."""
     dm = DMMock()
+    pos = SimPositioner(name=name, device_manager=dm)
+    yield pos
+
+
+@pytest.fixture(scope="function")
+def monitor(samx, name="monitor"):
+    """Fixture for SimMonitor."""
+    dm = samx.device_manager
+    samx.obj = samx  # Set obj attribute to itself for proxy lookup
+    dm.devices["samx"] = samx
     mon = SimMonitor(name=name, device_manager=dm)
+    mon.wait_for_connection()
     yield mon
 
 
@@ -97,6 +109,7 @@ def async_monitor(name="async_monitor"):
     """Fixture for SimMonitorAsync."""
     dm = DMMock()
     mon = SimMonitorAsync(name=name, device_manager=dm)
+    mon.wait_for_connection()
     yield mon
 
 
@@ -168,6 +181,7 @@ def test_monitor_with_sim_init():
     """Test to see if the sim init parameters are passed to the device"""
     dm = DMMock()
     sim = SimMonitor(name="sim", device_manager=dm)
+    sim.wait_for_connection()
     assert sim.sim._model._name == "constant"
     model = "GaussianModel"
     params = {
@@ -179,6 +193,7 @@ def test_monitor_with_sim_init():
         "ref_motor": "samy",
     }
     sim = SimMonitor(name="sim", device_manager=dm, sim_init={"model": model, "params": params})
+    sim.wait_for_connection()
     assert sim.sim._model._name == model.strip("Model").lower()
     diff_keys = set(sim.sim.params.keys()) - set(params.keys())
     for k in params:
@@ -224,9 +239,7 @@ def test_init_async_monitor(async_monitor):
 def test_monitor_readback(monitor, center, positioner):
     """Test the readback method of SimMonitor."""
     motor_pos = 0
-    samx = SimPositioner(name="samx", device_manager=monitor.device_manager)
-    setattr(samx, "obj", samx)  # Set obj attribute to itself for proxy lookup
-    monitor.device_manager.devices["samx"] = samx
+    samx = monitor.device_manager.devices.get("samx", None)
     for model_name in monitor.sim.get_models():
         monitor.sim.select_model(model_name)
         monitor.sim.params["noise_multipler"] = 10


### PR DESCRIPTION
LIttle PR to fix a thread leak for the `move` method of SimPositioner, and have SimMonitor to register a callback on any change of readback from the ref_motor.