### PR TITLE
Add ROIProcessing base class for ROI signals

### DIFF
--- a/ophyd_devices/interfaces/base_classes/psi_device_base.py
+++ b/ophyd_devices/interfaces/base_classes/psi_device_base.py
@@ -73,6 +73,20 @@ class PSIDeviceBase(Device):
         self.scan_info = scan_info
         self.on_init()
 
+    def wait_for_connection(self, *args, **kwargs):
+        """Wait for the device to be connected.
+
+        This method is called from BEC after the device is added to the device manager.
+        It waits for the device to be connected and then calls the on_connected method.
+        """
+        for walk in self.walk_components():
+            if (
+                hasattr(walk.item.cls, "REQUIRES_WAIT_FOR_CONNECTION")
+                and walk.item.cls.REQUIRES_WAIT_FOR_CONNECTION is True
+            ):
+                getattr(self, walk.dotted_name).wait_for_connection(*args, **kwargs)
+        super().wait_for_connection(*args, **kwargs)
+
     ########################################
     # Additional Properties and Attributes #
     ########################################

--- a/ophyd_devices/sim/sim_camera.py
+++ b/ophyd_devices/sim/sim_camera.py
@@ -15,7 +15,12 @@ from ophyd_devices.utils.bec_signals import FileEventSignal, PreviewSignal
 logger = bec_logger.logger
 
 SIM_CONFIG: LITERAL_ROI_PROCESSING_CONFIG = {
-    "basic_statistics": {"scalar_outputs": ["sum", "mean", "min", "max"], "waveform_outputs": []}
+    "basic_statistics": {
+        "scalar_outputs": ["sum", "mean", "min", "max"],
+        "waveform_outputs": [],
+        "enable_signal": None,
+        "source_signals": {},
+    }
 }
 
 

--- a/ophyd_devices/sim/sim_camera.py
+++ b/ophyd_devices/sim/sim_camera.py
@@ -23,10 +23,16 @@ class SimCameraROIProcessing(ROIProcessing):
     """ROI processing signal for simulated camera setups."""
 
     def get_scalar_outputs(self) -> list[str]:
-        return SIM_CONFIG["basic_statistics"]["scalar_outputs"]
+        scalar_outpus = []
+        for v in SIM_CONFIG.values():
+            scalar_outpus.extend(v["scalar_outputs"])
+        return scalar_outpus
 
     def get_waveform_outputs(self) -> list[str]:
-        return SIM_CONFIG["basic_statistics"]["waveform_outputs"]
+        waveform_outputs = []
+        for v in SIM_CONFIG.values():
+            waveform_outputs.extend(v["waveform_outputs"])
+        return waveform_outputs
 
     def get_available_analysis_operations(self) -> list[str]:
         return list(SIM_CONFIG.keys())

--- a/ophyd_devices/sim/sim_camera.py
+++ b/ophyd_devices/sim/sim_camera.py
@@ -9,9 +9,77 @@ from ophyd_devices.interfaces.base_classes.psi_device_base import PSIDeviceBase
 from ophyd_devices.sim.sim_data import SimulatedDataCamera
 from ophyd_devices.sim.sim_signals import ReadOnlySignal, SetableSignal
 from ophyd_devices.sim.sim_utils import H5Writer
+from ophyd_devices.utils.bec_roi_signals import LITERAL_ROI_PROCESSING_CONFIG, ROIProcessing
 from ophyd_devices.utils.bec_signals import FileEventSignal, PreviewSignal
 
 logger = bec_logger.logger
+
+SIM_CONFIG: LITERAL_ROI_PROCESSING_CONFIG = {
+    "basic_statistics": {"scalar_outputs": ["sum", "mean", "min", "max"], "waveform_outputs": []}
+}
+
+
+class SimCameraROIProcessing(ROIProcessing):
+    """ROI processing signal for simulated camera setups."""
+
+    def get_scalar_outputs(self) -> list[str]:
+        return SIM_CONFIG["basic_statistics"]["scalar_outputs"]
+
+    def get_waveform_outputs(self) -> list[str]:
+        return SIM_CONFIG["basic_statistics"]["waveform_outputs"]
+
+    def get_available_analysis_operations(self) -> list[str]:
+        return list(SIM_CONFIG.keys())
+
+    def wait_for_connection(self, *args, **kwargs):
+        super().wait_for_connection(*args, **kwargs)
+        self.parent.image.subscribe(
+            self._on_image_update, event_type=self.parent.image.SUB_VALUE, run=False
+        )
+
+    def _on_image_update(self, value, **kwargs):
+        """Callback for image updates."""
+        if not self.active.get():
+            return  # Do nothing if not enabled
+
+        if not isinstance(value, np.ndarray):
+            logger.warning(f"Received non-numpy array value: {value}")
+            return  # Do nothing if not numpy array
+        if "basic_statistics" not in self.selected_operations.get():
+            return
+        roi_image = self._extract_roi(value)
+        if roi_image.size == 0:
+            logger.warning(f"ROI {self.roi_name.get()} is outside image bounds or has zero size.")
+            return
+        self.result_scalar.put(self._compute_basic_statistics(roi_image))
+
+    def _extract_roi(self, image: np.ndarray) -> np.ndarray:
+        """Return the configured rectangular ROI clipped to the image bounds."""
+        x = int(self.x.get())
+        y = int(self.y.get())
+        width = int(self.width.get())
+        height = int(self.height.get())
+        if width <= 0 or height <= 0:
+            return image[0:0, 0:0]
+
+        x0 = max(0, x)
+        y0 = max(0, y)
+        x1 = min(image.shape[1], x + width)
+        y1 = min(image.shape[0], y + height)
+        if x1 <= x0 or y1 <= y0:
+            return image[0:0, 0:0]
+        return image[y0:y1, x0:x1]
+
+    def _compute_basic_statistics(self, image: np.ndarray) -> dict[str, dict[str, float]]:
+        """Compute basic statistics for the given image."""
+        timestamp = self.parent.image.timestamp
+        values = {
+            "sum": {"value": float(np.sum(image)), "timestamp": timestamp},
+            "mean": {"value": float(np.mean(image)), "timestamp": timestamp},
+            "min": {"value": float(np.min(image)), "timestamp": timestamp},
+            "max": {"value": float(np.max(image)), "timestamp": timestamp},
+        }
+        return {name: values[name] for name in self.get_scalar_outputs() if name in values}
 
 
 class SimCameraControl(Device):
@@ -73,6 +141,18 @@ class SimCamera(PSIDeviceBase, SimCameraControl):
     kind                    : A member the Kind IntEnum (or equivalent integer), optional. Default is Kind.normal. See Kind for options.
 
     """
+
+    roi_processing = Cpt(
+        SimCameraROIProcessing,
+        name="roi_processing",
+        active=True,
+        x=25,
+        y=25,
+        width=50,
+        height=50,
+        selected_operations=["basic_statistics"],
+        kind=Kind.normal,
+    )
 
     def __init__(self, name: str, scan_info=None, device_manager=None, **kwargs):
         super().__init__(name=name, scan_info=scan_info, device_manager=device_manager, **kwargs)

--- a/ophyd_devices/utils/bec_roi_signals/__init__.py
+++ b/ophyd_devices/utils/bec_roi_signals/__init__.py
@@ -1,0 +1,1 @@
+from .roi_processing import LITERAL_ROI_PROCESSING_CONFIG, ROIProcessing

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -82,7 +82,7 @@ class StatsPluginWithTSControl(StatsPlugin_V35):
     ts_read_mode = Cpt(EpicsSignal, "TS:TSRead.SCAN", kind=Kind.omitted)
     ts_read = Cpt(EpicsSignal, "TS:TSRead.PROC", kind=Kind.omitted)
     ts_current_index = Cpt(EpicsSignalRO, "TS:TSCurrentPoint", kind=Kind.omitted)
-    ts_num_points = Cpt(EpicsSignalRO, "TS:TSNumPoints", kind=Kind.omitted, auto_monitor=True)
+    ts_num_points = Cpt(EpicsSignal, "TS:TSNumPoints", kind=Kind.omitted, auto_monitor=True)
 
 
 @dataclass

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -375,7 +375,6 @@ class ADROIProcessing(ROIProcessing):
 
     def on_destroy(self):
         """Hook called when the device is destroyed."""
-        self.stats1.ts_acquire.put(0)  # Stop timestamp acquisition
         self._unsubscribe_all_stats()
 
 

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -179,6 +179,7 @@ class ADROIProcessing(ROIProcessing):
     def wait_for_connection(self, *args, **kwargs):
         super().wait_for_connection(*args, **kwargs)
         # Subscribe stats plugin to ROI plugin
+        self.roi1.nd_array_port.put(self.cam1.port_name.get())
         self.stats1.nd_array_port.put(self.roi1.port_name.get())
         # ROIPlugin related callbacks
         self.selected_operations.subscribe(
@@ -351,8 +352,8 @@ class MyDetector(PSIDeviceBase, ADBase):
         doc="Preview signal for the camera.",
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args, device_manager=None, **kwargs):
+        super().__init__(*args, device_manager=device_manager, **kwargs)
         self._poll_thread_kill_event = threading.Event()
         self._poll_rate = 1.0  # Hz
         self._unique_array_id = None

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -178,6 +178,8 @@ class ADROIProcessing(ROIProcessing):
 
     def wait_for_connection(self, *args, **kwargs):
         super().wait_for_connection(*args, **kwargs)
+        # Subscribe stats plugin to ROI plugin
+        self.stats1.nd_array_port.put(self.roi1.port_name.get())
         # ROIPlugin related callbacks
         self.selected_operations.subscribe(
             self._on_processing_selection_update,

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -346,9 +346,9 @@ class ADROIProcessing(ROIProcessing):
             if isinstance(value, (list, np.ndarray)):
                 value = value / len(value)  # Average over the number of frames per trigger
             value = float(value)  # Ensure the value is a float for list and np.ndarray types
-            async_update["max_shape"] = [len(
-                self.scan_server_scan_info.positions
-            )  # Only one value per position
+            async_update["max_shape"] = [
+                len(self.scan_server_scan_info.positions)
+            ]  # Only one value per position
 
         if output_kind == "scalar":
             self.result_scalar.put(

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -364,7 +364,7 @@ class MyDetector(PSIDeviceBase, ADBase):
         y=400,
         width=100,
         height=100,
-        selected_operations=["basic_statistics", "histogram"],
+        selected_operations=["basic_statistics", "profiles"],
     )
 
     preview = Cpt(

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -312,7 +312,66 @@ class ADROIProcessing(ROIProcessing):
         return bool(self.active.get()) and operation in self.selected_operations.get()
 
 
-class MyDevice(Device):
-    """Example device with ROI processing."""
+import threading
+import traceback
 
+from ophyd import ADBase
+
+from ophyd_devices import PreviewSignal
+from ophyd_devices.devices.areadetector.cam import SimDetectorCam
+from ophyd_devices.devices.areadetector.plugins import ImagePlugin_V35 as ImagePlugin
+
+
+class MyDetector(ADBase):
+    cam = Cpt(SimDetectorCam, "cam1:")
+    image = Cpt(ImagePlugin, "image1:")
     roi_processing = Cpt(ADROIProcessing, prefix="ROI1:", kind="normal")
+
+    preview = Cpt(
+        PreviewSignal,
+        name="preview",
+        ndim=2,
+        num_rotation_90=0,
+        doc="Preview signal for the camera.",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._poll_thread_kill_event = threading.Event()
+        self._poll_rate = 1.0  # Hz
+        self._unique_array_id = None
+        self._poll_thread = threading.Thread(
+            target=self._poll_array_data, daemon=True, name=f"{self.name}_poll_thread"
+        )
+
+    def wait_for_connection(self, *args, **kwargs):
+        super().wait_for_connection(*args, **kwargs)
+        self._poll_thread.start()
+
+    def _poll_array_data(self):
+        """Poll the array data for preview updates."""
+        while not self._poll_thread_kill_event.wait(1 / self._poll_rate):
+            try:
+                # First check if there is a new image
+                if self.image.unique_id.get() != self._unique_array_id:
+                    self._unique_array_id = self.image.unique_id.get()
+                else:
+                    logger.info(f"No new image for preview of {self.name}, skipping update.")
+                    continue  # No new image, skip update
+                # Get new image data
+                value = self.image.array_data.get()
+                if value is None:
+                    logger.info(f"No image data available for preview of {self.name}")
+                    continue
+
+                width = self.image.array_size.width.get()
+                height = self.image.array_size.height.get()
+                # Geometry correction for the image
+                data = np.reshape(value, (height, width))
+                logger.info(f"Setting preview data for {self.name} with shape {data.shape}")
+                self.preview.put(data)
+            except Exception:  # pylint: disable=broad-except
+                content = traceback.format_exc()
+                logger.error(
+                    f"Error while polling array data for preview of {self.name}: {content}"
+                )

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -407,3 +407,9 @@ class MyDetector(PSIDeviceBase, ADBase):
                 logger.error(
                     f"Error while polling array data for preview of {self.name}: {content}"
                 )
+
+    def destroy(self):
+        """Clean up resources."""
+        self._poll_thread_kill_event.set()
+        if self._poll_thread.is_alive():
+            self._poll_thread.join(timeout=0.5)

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -176,7 +176,7 @@ class ADROIProcessing(ROIProcessing):
     roi1 = Cpt(ROIPlugin, "ROI1:", kind="normal")
     stats1 = Cpt(StatsPluginWithTSControl, "Stats1:", kind="normal")
     average_frames_per_trigger = Cpt(
-        AverageFramesForEachTrigger, "average_frames_per_trigger", kind=Kind.config, value=True
+        AverageFramesForEachTrigger, name="average_frames_per_trigger", kind=Kind.config, value=True
     )
 
     def __init__(self, *args, **kwargs):

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -223,6 +223,9 @@ class ADROIProcessing(ROIProcessing):
         for key in set(self._stats_subscriptions) - set(desired):
             subscription = self._stats_subscriptions.pop(key)
             subscription.signal.unsubscribe(subscription.callback_id)
+            logger.info(
+                f"Unsubscribed from StatsPlugin output {subscription.operation}.{subscription.result_name} ({subscription.output_kind})"
+            )
 
         for key, (operation, result_name, output_kind, dotted_name) in desired.items():
             if key in self._stats_subscriptions:
@@ -243,6 +246,9 @@ class ADROIProcessing(ROIProcessing):
                 operation=operation,
                 result_name=result_name,
                 output_kind=output_kind,
+            )
+            logger.info(
+                f"Subscribed to StatsPlugin output {operation}.{result_name} ({output_kind})"
             )
 
         self._apply_stats_enable_signals()
@@ -319,6 +325,7 @@ class ADROIProcessing(ROIProcessing):
         **kwargs,
     ) -> None:
         """Publish a StatsPlugin update into the matching BEC result signal."""
+        logger.info(f"StatsPlugin update for {operation}.{result_name} ({output_kind}): {value}")
         if not self._is_operation_active(operation):
             return
 

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -24,10 +24,16 @@ class ADROIProcessing(ROIProcessing):
     stats1 = Cpt(StatsPlugin, prefix="STATS1:", kind="normal")
 
     def get_scalar_outputs(self) -> list[str]:
-        return NDPLUGIN_STATS_CONFIG["basic_statistics"]["scalar_outputs"]
+        scalar_outpus = []
+        for v in NDPLUGIN_STATS_CONFIG.values():
+            scalar_outpus.extend(v["scalar_outputs"])
+        return scalar_outpus
 
     def get_waveform_outputs(self) -> list[str]:
-        return NDPLUGIN_STATS_CONFIG["basic_statistics"]["waveform_outputs"]
+        waveform_outputs = []
+        for v in NDPLUGIN_STATS_CONFIG.values():
+            waveform_outputs.extend(v["waveform_outputs"])
+        return waveform_outputs
 
     def get_available_analysis_operations(self) -> list[str]:
         return list(NDPLUGIN_STATS_CONFIG.keys())

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from ophyd import Component as Cpt
+from ophyd import Device
+
+from ophyd_devices.devices.areadetector.plugins import ROIPlugin, StatsPlugin
+from ophyd_devices.utils.bec_roi_signals.roi_processing import (
+    LITERAL_ROI_PROCESSING_CONFIG,
+    ROIProcessing,
+)
+
+NDPLUGIN_STATS_CONFIG: LITERAL_ROI_PROCESSING_CONFIG = {
+    "basic_statistics": {
+        "scalar_outputs": ["sum", "mean", "min", "max", "sigma"],
+        "waveform_outputs": [],
+    }
+}
+
+
+class ADROIProcessing(ROIProcessing):
+    """ROI processing signal for AD detector setups at PSI."""
+
+    roi1 = Cpt(ROIPlugin, prefix="ROI1:", kind="normal")
+    stats1 = Cpt(StatsPlugin, prefix="STATS1:", kind="normal")
+
+    def get_scalar_outputs(self) -> list[str]:
+        return NDPLUGIN_STATS_CONFIG["basic_statistics"]["scalar_outputs"]
+
+    def get_waveform_outputs(self) -> list[str]:
+        return NDPLUGIN_STATS_CONFIG["basic_statistics"]["waveform_outputs"]
+
+    def get_available_analysis_operations(self) -> list[str]:
+        return list(NDPLUGIN_STATS_CONFIG.keys())
+
+
+class MyDevice(Device):
+    """Example device with ROI processing."""
+
+    roi_processing = Cpt(ADROIProcessing, prefix="ROI1:", kind="normal")

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -18,15 +18,15 @@ from ophyd_devices.utils.bec_roi_signals.roi_processing import (
 
 
 class StatsPlugin(StatsPlugin_V35):
-    plugin_type = None
-    codec = None
-    compressed_size = None
+    # plugin_type = None
+    # codec = None
+    # compressed_size = None
 
 
 class ROIPlugin(ROIPlugin_V35):
-    plugin_type = None
-    codec = None
-    compressed_size = None
+    # plugin_type = None
+    # codec = None
+    # compressed_size = None
 
 
 logger = bec_logger.logger

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -331,12 +331,17 @@ class ADROIProcessing(ROIProcessing):
 
 import threading
 import traceback
+from typing import TYPE_CHECKING
 
 from ophyd import ADBase
 
 from ophyd_devices import PreviewSignal, PSIDeviceBase
 from ophyd_devices.devices.areadetector.cam import SimDetectorCam
 from ophyd_devices.devices.areadetector.plugins import ImagePlugin_V35 as ImagePlugin
+
+if TYPE_CHECKING:
+    from bec_lib.devicemanager import ScanInfo
+    from bec_server.device_server.devices.devicemanager import DeviceManagerDS
 
 
 class MyDetector(PSIDeviceBase, ADBase):
@@ -352,15 +357,18 @@ class MyDetector(PSIDeviceBase, ADBase):
         doc="Preview signal for the camera.",
     )
 
-    def __init__(self, 
-            *,
-            name: str,
-            prefix: str = "",
-            scan_info: ScanInfo | None = None,
-            device_manager: DeviceManagerBase | None = None,
-            **kwargs,
+    def __init__(
+        self,
+        *,
+        name: str,
+        prefix: str = "",
+        scan_info: ScanInfo | None = None,
+        device_manager: DeviceManagerDS | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            name=name, prefix=prefix, scan_info=scan_info, device_manager=device_manager, **kwargs
         )
-        super().__init__(name=name, prefix=prefix, scan_info=scan_info, device_manager=device_manager, **kwargs)
         self._poll_thread_kill_event = threading.Event()
         self._poll_rate = 1.0  # Hz
         self._unique_array_id = None

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -419,7 +419,7 @@ class MyDetector(PSIDeviceBase, ADBase):
                     f"Error while polling array data for preview of {self.name}: {content}"
                 )
 
-    def destroy(self):
+    def on_destroy(self):
         """Clean up resources."""
         self._poll_thread_kill_event.set()
         if self._poll_thread.is_alive():

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -76,7 +76,7 @@ class TSReadMode(IntEnum):
 class StatsPluginWithTSControl(StatsPlugin_V35):
     """StatsPlugin with additional timestamp control signals."""
 
-    ts_acquire_status = Cpt(EpicsSignalRO, ":TS:TSAcquiring", kind=Kind.omitted, auto_monitor=True)
+    ts_acquire_status = Cpt(EpicsSignalRO, "TS:TSAcquiring", kind=Kind.omitted, auto_monitor=True)
     ts_acquire = Cpt(EpicsSignal, "TS:TSAcquire", kind=Kind.omitted)
     ts_acquire_mode = Cpt(EpicsSignal, "TS:TSAcquireMode", kind=Kind.omitted)
     ts_read_mode = Cpt(EpicsSignal, "TS:TSRead.SCAN", kind=Kind.omitted)

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -1,19 +1,137 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Literal
+
+import numpy as np
+from bec_lib.logger import bec_logger
+from bec_lib.utils.rpc_utils import rgetattr
 from ophyd import Component as Cpt
 from ophyd import Device
 
-from ophyd_devices.devices.areadetector.plugins import ROIPlugin, StatsPlugin
+from ophyd_devices.devices.areadetector.plugins import ROIPlugin
+from ophyd_devices.devices.areadetector.plugins import StatsPlugin_V35 as StatsPlugin
 from ophyd_devices.utils.bec_roi_signals.roi_processing import (
     LITERAL_ROI_PROCESSING_CONFIG,
     ROIProcessing,
 )
 
+logger = bec_logger.logger
+
+
+@dataclass
+class StatsSubscription:
+    """Bookkeeping for callbacks subscribed to StatsPlugin output signals."""
+
+    signal: Any
+    callback_id: int
+    operation: str
+    result_name: str
+    output_kind: Literal["scalar", "waveform"]
+
+
 NDPLUGIN_STATS_CONFIG: LITERAL_ROI_PROCESSING_CONFIG = {
     "basic_statistics": {
-        "scalar_outputs": ["sum", "mean", "min", "max", "sigma"],
+        "enable_signal": "compute_statistics",
+        "scalar_outputs": [
+            "min",
+            "min_x",
+            "min_y",
+            "max",
+            "max_x",
+            "max_y",
+            "mean",
+            "total",
+            "net",
+            "sigma",
+        ],
         "waveform_outputs": [],
-    }
+        "source_signals": {
+            "min": "min_value",
+            "min_x": "min_xy.x",
+            "min_y": "min_xy.y",
+            "max": "max_value",
+            "max_x": "max_xy.x",
+            "max_y": "max_xy.y",
+            "mean": "mean_value",
+            "total": "total",
+            "net": "net",
+            "sigma": "sigma_readout",
+        },
+    },
+    "centroid": {
+        "enable_signal": "compute_centroid",
+        "scalar_outputs": [
+            "centroid_total",
+            "centroid_x",
+            "centroid_y",
+            "sigma_x",
+            "sigma_y",
+            "sigma_xy",
+            "skew_x",
+            "skew_y",
+            "kurtosis_x",
+            "kurtosis_y",
+            "eccentricity",
+            "orientation",
+        ],
+        "waveform_outputs": [],
+        "source_signals": {
+            "centroid_total": "centroid_total",
+            "centroid_x": "centroid.x",
+            "centroid_y": "centroid.y",
+            "sigma_x": "sigma_x",
+            "sigma_y": "sigma_y",
+            "sigma_xy": "sigma_xy",
+            "skew_x": "skew.x",
+            "skew_y": "skew.y",
+            "kurtosis_x": "kurtosis.x",
+            "kurtosis_y": "kurtosis.y",
+            "eccentricity": "eccentricity",
+            "orientation": "orientation",
+        },
+    },
+    "profiles": {
+        "enable_signal": "compute_profiles",
+        "scalar_outputs": ["profile_size_x", "profile_size_y", "cursor_x", "cursor_y"],
+        "waveform_outputs": [
+            "profile_average_x",
+            "profile_average_y",
+            "profile_threshold_x",
+            "profile_threshold_y",
+            "profile_centroid_x",
+            "profile_centroid_y",
+            "profile_cursor_x",
+            "profile_cursor_y",
+        ],
+        "source_signals": {
+            "profile_size_x": "profile_size.x",
+            "profile_size_y": "profile_size.y",
+            "cursor_x": "cursor.x",
+            "cursor_y": "cursor.y",
+            "profile_average_x": "profile_average.x",
+            "profile_average_y": "profile_average.y",
+            "profile_threshold_x": "profile_threshold.x",
+            "profile_threshold_y": "profile_threshold.y",
+            "profile_centroid_x": "profile_centroid.x",
+            "profile_centroid_y": "profile_centroid.y",
+            "profile_cursor_x": "profile_cursor.x",
+            "profile_cursor_y": "profile_cursor.y",
+        },
+    },
+    "histogram": {
+        "enable_signal": "compute_histogram",
+        "scalar_outputs": ["hist_below", "hist_above", "hist_entropy"],
+        "waveform_outputs": ["histogram", "histogram_x"],
+        "source_signals": {
+            "hist_below": "hist_below",
+            "hist_above": "hist_above",
+            "hist_entropy": "hist_entropy",
+            "histogram": "histogram",
+            "histogram_x": "histogram_x",
+        },
+    },
 }
 
 
@@ -23,20 +141,175 @@ class ADROIProcessing(ROIProcessing):
     roi1 = Cpt(ROIPlugin, prefix="ROI1:", kind="normal")
     stats1 = Cpt(StatsPlugin, prefix="STATS1:", kind="normal")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._stats_subscriptions: dict[str, StatsSubscription] = {}
+        self._missing_stats_paths: set[str] = set()
+        self._config_update_in_progress = False
+
     def get_scalar_outputs(self) -> list[str]:
-        scalar_outpus = []
-        for v in NDPLUGIN_STATS_CONFIG.values():
-            scalar_outpus.extend(v["scalar_outputs"])
-        return scalar_outpus
+        scalar_outputs = []
+        for config in NDPLUGIN_STATS_CONFIG.values():
+            scalar_outputs.extend(config.get("scalar_outputs", []))
+        return scalar_outputs
 
     def get_waveform_outputs(self) -> list[str]:
         waveform_outputs = []
-        for v in NDPLUGIN_STATS_CONFIG.values():
-            waveform_outputs.extend(v["waveform_outputs"])
+        for config in NDPLUGIN_STATS_CONFIG.values():
+            waveform_outputs.extend(config.get("waveform_outputs", []))
         return waveform_outputs
 
     def get_available_analysis_operations(self) -> list[str]:
         return list(NDPLUGIN_STATS_CONFIG.keys())
+
+    def wait_for_connection(self, *args, **kwargs):
+        super().wait_for_connection(*args, **kwargs)
+        # ROIPlugin related callbacks
+        self.selected_operations.subscribe(
+            self._on_processing_selection_update,
+            event_type=self.selected_operations.SUB_VALUE,
+            run=False,
+        )
+        self._apply_roi_configuration()
+        self._sync_stats_subscriptions()
+
+    def destroy(self):
+        self._unsubscribe_all_stats()
+        super().destroy()
+
+    def _on_config_update(self, value, **kwargs):
+        self._config_update_in_progress = True
+        try:
+            super()._on_config_update(value, **kwargs)
+        finally:
+            self._config_update_in_progress = False
+
+        self._apply_roi_configuration()
+        self._sync_stats_subscriptions()
+
+    def _on_processing_selection_update(self, *args, **kwargs) -> None:
+        if self._config_update_in_progress:
+            return
+        self._sync_stats_subscriptions()
+
+    def _apply_roi_configuration(self) -> None:
+        """Apply the BEC ROI geometry to the AreaDetector ROI plugin."""
+        self.roi1.min_xyz.min_x.put(int(self.x.get()))
+        self.roi1.min_xyz.min_y.put(int(self.y.get()))
+        self.roi1.size.x.put(int(self.width.get()))
+        self.roi1.size.y.put(int(self.height.get()))
+
+    def _sync_stats_subscriptions(self) -> None:
+        """Subscribe to selected StatsPlugin outputs and unsubscribe stale ones."""
+        desired = self._desired_stats_outputs()
+
+        for key in set(self._stats_subscriptions) - set(desired):
+            subscription = self._stats_subscriptions.pop(key)
+            subscription.signal.unsubscribe(subscription.callback_id)
+
+        for key, (operation, result_name, output_kind, dotted_name) in desired.items():
+            if key in self._stats_subscriptions:
+                continue
+            signal = self._resolve_stats_signal(dotted_name)
+            if signal is None:
+                continue
+            callback = partial(
+                self._on_stats_signal_update,
+                operation=operation,
+                result_name=result_name,
+                output_kind=output_kind,
+            )
+            callback_id = signal.subscribe(callback, event_type=signal.SUB_VALUE, run=False)
+            self._stats_subscriptions[key] = StatsSubscription(
+                signal=signal,
+                callback_id=callback_id,
+                operation=operation,
+                result_name=result_name,
+                output_kind=output_kind,
+            )
+
+        self._apply_stats_enable_signals()
+
+    def _desired_stats_outputs(
+        self,
+    ) -> dict[str, tuple[str, str, Literal["scalar", "waveform"], str]]:
+        if not self.active.get():
+            return {}
+
+        selected_operations = set(self.selected_operations.get())
+        desired = {}
+        for operation, config in NDPLUGIN_STATS_CONFIG.items():
+            if operation not in selected_operations:
+                continue
+            source_signals = config.get("source_signals", {})
+            for result_name in config.get("scalar_outputs", []):
+                signal_path = source_signals[result_name]
+                desired[f"scalar:{operation}:{result_name}"] = (
+                    operation,
+                    result_name,
+                    "scalar",
+                    signal_path,
+                )
+            for result_name in config.get("waveform_outputs", []):
+                signal_path = source_signals[result_name]
+                desired[f"waveform:{operation}:{result_name}"] = (
+                    operation,
+                    result_name,
+                    "waveform",
+                    signal_path,
+                )
+        return desired
+
+    def _unsubscribe_all_stats(self) -> None:
+        for subscription in self._stats_subscriptions.values():
+            subscription.signal.unsubscribe(subscription.callback_id)
+        self._stats_subscriptions.clear()
+
+    def _apply_stats_enable_signals(self) -> None:
+        selected_operations = set(self.selected_operations.get()) if self.active.get() else set()
+        for operation, config in NDPLUGIN_STATS_CONFIG.items():
+            enable_signal = config.get("enable_signal")
+            if enable_signal is None:
+                continue
+            signal = self._resolve_stats_signal(enable_signal)
+            if signal is None:
+                continue
+            signal.put("Yes" if operation in selected_operations else "No")
+
+    def _resolve_stats_signal(self, signal_path: str):
+        """Resolve a dotted StatsPlugin attribute path to an ophyd signal."""
+        try:
+            signal = rgetattr(self.stats1, signal_path)  # Check if the attribute exists
+        except AttributeError:
+            if signal_path not in self._missing_stats_paths:
+                logger.warning(
+                    "StatsPlugin signal path %s is not available on %s.",
+                    signal_path,
+                    self.stats1.__class__.__name__,
+                )
+                self._missing_stats_paths.add(signal_path)
+            return None
+        return signal
+
+    def _on_stats_signal_update(
+        self,
+        *,
+        operation: str,
+        result_name: str,
+        output_kind: Literal["scalar", "waveform"],
+        value,
+        timestamp=None,
+        **kwargs,
+    ) -> None:
+        """Publish a StatsPlugin update into the matching BEC result signal."""
+        if not self._is_operation_active(operation):
+            return
+
+        signal = self.result_scalar if output_kind == "scalar" else self.result_waveform
+        signal.put({result_name: {"value": value, "timestamp": timestamp or self._get_timestamp()}})
+
+    def _is_operation_active(self, operation: str) -> bool:
+        return bool(self.active.get()) and operation in self.selected_operations.get()
 
 
 class MyDevice(Device):

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -346,7 +346,7 @@ class ADROIProcessing(ROIProcessing):
             if isinstance(value, (list, np.ndarray)):
                 value = value / len(value)  # Average over the number of frames per trigger
             value = float(value)  # Ensure the value is a float for list and np.ndarray types
-            async_update["max_shape"] = len(
+            async_update["max_shape"] = [len(
                 self.scan_server_scan_info.positions
             )  # Only one value per position
 

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -347,7 +347,18 @@ if TYPE_CHECKING:
 class MyDetector(PSIDeviceBase, ADBase):
     cam = Cpt(SimDetectorCam, "cam1:")
     image = Cpt(ImagePlugin, "image1:")
-    roi_processing = Cpt(ADROIProcessing, "", kind="normal")
+    roi_processing = Cpt(
+        ADROIProcessing,
+        "",
+        kind="normal",
+        active=1,
+        roi_name="roi1",
+        x=400,
+        y=400,
+        width=100,
+        height=100,
+        selected_operations=["basic_statistics", "histogram"],
+    )
 
     preview = Cpt(
         PreviewSignal,

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -150,8 +150,8 @@ NDPLUGIN_STATS_CONFIG: LITERAL_ROI_PROCESSING_CONFIG = {
 class ADROIProcessing(ROIProcessing):
     """ROI processing signal for AD detector setups at PSI."""
 
-    roi1 = Cpt(ROIPlugin, prefix="ROI1:", kind="normal")
-    stats1 = Cpt(StatsPlugin, prefix="STATS1:", kind="normal")
+    roi1 = Cpt(ROIPlugin, "ROI1:", kind="normal")
+    stats1 = Cpt(StatsPlugin, "STATS1:", kind="normal")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -337,7 +337,7 @@ from ophyd_devices.devices.areadetector.plugins import ImagePlugin_V35 as ImageP
 class MyDetector(PSIDeviceBase, ADBase):
     cam = Cpt(SimDetectorCam, "cam1:")
     image = Cpt(ImagePlugin, "image1:")
-    roi_processing = Cpt(ADROIProcessing, prefix="ROI1:", kind="normal")
+    roi_processing = Cpt(ADROIProcessing, "", kind="normal")
 
     preview = Cpt(
         PreviewSignal,

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -335,29 +335,25 @@ class ADROIProcessing(ROIProcessing):
             return
         if not self.scan_server_scan_info:
             return
-        async_update = {
-            "type": "add",
-            "max_shape": [
-                self.scan_server_scan_info.frames_per_trigger
-                * len(self.scan_server_scan_info.positions)
-            ],
-        }
+
+        n_points = int(
+            len(self.scan_server_scan_info.positions)
+            * self.scan_server_scan_info.frames_per_trigger
+        )
         if self.average_frames_per_trigger.get() is True:
+            n_points = int(len(self.scan_server_scan_info.positions))
             if isinstance(value, (list, np.ndarray)):
                 value = value / len(value)  # Average over the number of frames per trigger
             value = float(value)  # Ensure the value is a float for list and np.ndarray types
-            async_update["max_shape"] = [
-                len(self.scan_server_scan_info.positions)
-            ]  # Only one value per position
 
         if output_kind == "scalar":
+            async_update = {"type": "add", "max_shape": [n_points]}
             self.result_scalar.put(
                 {result_name: {"value": value, "timestamp": timestamp or time.time()}},
                 async_update=async_update,
             )
         else:
-            shape_0 = async_update["max_shape"][0]
-            async_update["max_shape"] = [shape_0, None]  # Allow the second dimension to be variable
+            async_update = {"type": "add", "max_shape": [n_points, None]}
             self.result_waveform.put(
                 {result_name: {"value": value, "timestamp": timestamp or time.time()}},
                 async_update=async_update,

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -352,8 +352,15 @@ class MyDetector(PSIDeviceBase, ADBase):
         doc="Preview signal for the camera.",
     )
 
-    def __init__(self, *args, device_manager=None, **kwargs):
-        super().__init__(*args, device_manager=device_manager, **kwargs)
+    def __init__(self, 
+            *,
+            name: str,
+            prefix: str = "",
+            scan_info: ScanInfo | None = None,
+            device_manager: DeviceManagerBase | None = None,
+            **kwargs,
+        )
+        super().__init__(name=name, prefix=prefix, scan_info=scan_info, device_manager=device_manager, **kwargs)
         self._poll_thread_kill_event = threading.Event()
         self._poll_rate = 1.0  # Hz
         self._unique_array_id = None

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -411,7 +411,7 @@ class MyDetector(PSIDeviceBase, ADBase):
         y=400,
         width=100,
         height=100,
-        selected_operations=["basic_statistics", "profiles"],
+        selected_operations=["basic_statistics", "centroid"],
     )
 
     preview = Cpt(

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -178,8 +178,8 @@ class ADROIProcessing(ROIProcessing):
 
     def wait_for_connection(self, *args, **kwargs):
         super().wait_for_connection(*args, **kwargs)
-        # Subscribe stats plugin to ROI plugin
-        self.roi1.nd_array_port.put(self.cam1.port_name.get())
+        # Subscribe stats plugin to ROI plugin,  the self.root.cam assumes cam to be available on root object, so we trust roi1 to be properly configured.
+        # self.roi1.nd_array_port.put(self.root.cam.port_name.get())
         self.stats1.nd_array_port.put(self.roi1.port_name.get())
         # ROIPlugin related callbacks
         self.selected_operations.subscribe(

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -18,12 +18,14 @@ from ophyd_devices.utils.bec_roi_signals.roi_processing import (
 
 
 class StatsPlugin(StatsPlugin_V35):
+    pass
     # plugin_type = None
     # codec = None
     # compressed_size = None
 
 
 class ROIPlugin(ROIPlugin_V35):
+    pass
     # plugin_type = None
     # codec = None
     # compressed_size = None

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -333,13 +333,35 @@ class ADROIProcessing(ROIProcessing):
         """Publish a StatsPlugin update into the matching BEC result signal."""
         if not self._is_operation_active(operation):
             return
+        if not self.scan_server_scan_info:
+            return
+        async_update = {
+            "type": "add",
+            "max_shape": [
+                self.scan_server_scan_info.frames_per_trigger
+                * len(self.scan_server_scan_info.positions)
+            ],
+        }
         if self.average_frames_per_trigger.get() is True:
             if isinstance(value, (list, np.ndarray)):
                 value = value / len(value)  # Average over the number of frames per trigger
             value = float(value)  # Ensure the value is a float for list and np.ndarray types
+            async_update["max_shape"] = len(
+                self.scan_server_scan_info.positions
+            )  # Only one value per position
 
-        signal = self.result_scalar if output_kind == "scalar" else self.result_waveform
-        signal.put({result_name: {"value": value, "timestamp": timestamp or time.time()}})
+        if output_kind == "scalar":
+            self.result_scalar.put(
+                {result_name: {"value": value, "timestamp": timestamp or time.time()}},
+                async_update=async_update,
+            )
+        else:
+            shape_0 = async_update["max_shape"][0]
+            async_update["max_shape"] = [shape_0, None]  # Allow the second dimension to be variable
+            self.result_waveform.put(
+                {result_name: {"value": value, "timestamp": timestamp or time.time()}},
+                async_update=async_update,
+            )
 
     def _is_operation_active(self, operation: str) -> bool:
         return bool(self.active.get()) and operation in self.selected_operations.get()

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -25,6 +25,8 @@ class StatsPlugin(StatsPlugin_V35):
 
 class ROIPlugin(ROIPlugin_V35):
     plugin_type = None
+    codec = None
+    compressed_size = None
 
 
 logger = bec_logger.logger

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -10,12 +10,22 @@ from bec_lib.utils.rpc_utils import rgetattr
 from ophyd import Component as Cpt
 from ophyd import Device
 
-from ophyd_devices.devices.areadetector.plugins import ROIPlugin
-from ophyd_devices.devices.areadetector.plugins import StatsPlugin_V35 as StatsPlugin
+from ophyd_devices.devices.areadetector.plugins import ROIPlugin_V35, StatsPlugin_V35
 from ophyd_devices.utils.bec_roi_signals.roi_processing import (
     LITERAL_ROI_PROCESSING_CONFIG,
     ROIProcessing,
 )
+
+
+class StatsPlugin(StatsPlugin_V35):
+    plugin_type = None
+    codec = None
+    compressed_size = None
+
+
+class ROIPlugin(ROIPlugin_V35):
+    plugin_type = None
+
 
 logger = bec_logger.logger
 

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -1,37 +1,88 @@
+"""Custom ROI processing Device for AreaDetector ROI/Stats plugin processing."""
+
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
+from enum import IntEnum
 from functools import partial
+from time import time
 from typing import Any, Literal
 
 import numpy as np
+from bec_lib.devicemanager import ScanInfo
 from bec_lib.logger import bec_logger
 from bec_lib.utils.rpc_utils import rgetattr
+from bec_server.scan_server.scans.scan_base import ScanInfo as ScanServerScanInfo
 from ophyd import Component as Cpt
-from ophyd import Device
+from ophyd import EpicsSignal, EpicsSignalRO, Kind, Signal
+from pydantic import ValidationError
 
-from ophyd_devices.devices.areadetector.plugins import ROIPlugin_V35, StatsPlugin_V35
+from ophyd_devices import TransitionStatus
+from ophyd_devices.devices.areadetector.plugins import ROIPlugin_V35 as ROIPlugin
+from ophyd_devices.devices.areadetector.plugins import StatsPlugin_V35
 from ophyd_devices.utils.bec_roi_signals.roi_processing import (
     LITERAL_ROI_PROCESSING_CONFIG,
     ROIProcessing,
 )
 
-
-class StatsPlugin(StatsPlugin_V35):
-    pass
-    # plugin_type = None
-    # codec = None
-    # compressed_size = None
+"""Utility functions for the devices."""
 
 
-class ROIPlugin(ROIPlugin_V35):
-    pass
-    # plugin_type = None
-    # codec = None
-    # compressed_size = None
+def fetch_scan_info(scan_info: ScanInfo) -> ScanServerScanInfo:
+    """Fetch the scan parameters from the scan_info object and return them as a ScanServerScanInfo object."""
+    info = scan_info.msg.info
+    if isinstance(info["positions"], list):
+        info["positions"] = np.array(info["positions"])
+    info["num_monitored_readouts"] = scan_info.msg.num_monitored_readouts
+    try:
+        msg = ScanServerScanInfo.model_validate(info)
+    except ValidationError:  # This means we have an old scan_info object.
+        info = deepcopy(info)
+        # We need to convert a few parameters manually.
+        info["scan_type"] = (
+            "hardware_triggered" if info["scan_type"] == "fly" else "software_triggered"
+        )
+        msg = ScanServerScanInfo.model_validate(info)
+
+    return msg
 
 
 logger = bec_logger.logger
+
+
+class TSAcquireMode(IntEnum):
+    """Enum for TSAcquireMode values."""
+
+    FIXED_LENGTH = 0
+    CIRCULAR_BUFFER = 1
+
+
+class TSReadMode(IntEnum):
+    """Enum for TSReadMode values. Recommend to use PASSIVE mode for most applications."""
+
+    PASSIVE = 0
+    EVENT = 1
+    IO_INTR = 2
+    TEN_SECOND = 3
+    FIVE_SECOND = 4
+    TWO_SECOND = 5
+    ONE_SECOND = 6
+    HALF_SECOND = 7
+    TWO_TENTHS_SECOND = 8
+    ONE_TENTH_SECOND = 9
+
+
+class StatsPluginWithTSControl(StatsPlugin_V35):
+    """StatsPlugin with additional timestamp control signals."""
+
+    ts_acquire_status = Cpt(EpicsSignalRO, ":TS:TSAcquiring", kind=Kind.omitted, auto_monitor=True)
+    ts_acquire = Cpt(EpicsSignal, "TS:TSAcquire", kind=Kind.omitted)
+    ts_acquire_mode = Cpt(EpicsSignal, "TS:TSAcquireMode", kind=Kind.omitted)
+    ts_read_mode = Cpt(EpicsSignal, "TS:TSRead.SCAN", kind=Kind.omitted)
+    ts_read = Cpt(EpicsSignal, "TS:TSRead.PROC", kind=Kind.omitted)
+    ts_current_index = Cpt(EpicsSignalRO, "TS:TSCurrentPoint", kind=Kind.omitted)
+    ts_num_points = Cpt(EpicsSignalRO, "TS:TSNumPoints", kind=Kind.omitted, auto_monitor=True)
 
 
 @dataclass
@@ -49,35 +100,35 @@ NDPLUGIN_STATS_CONFIG: LITERAL_ROI_PROCESSING_CONFIG = {
     "basic_statistics": {
         "enable_signal": "compute_statistics",
         "scalar_outputs": [
-            "min",
+            "min_value",
             "min_x",
             "min_y",
-            "max",
+            "max_value",
             "max_x",
             "max_y",
-            "mean",
+            "mean_value",
+            "sigma",
             "total",
             "net",
-            "sigma",
         ],
         "waveform_outputs": [],
         "source_signals": {
-            "min": "min_value",
-            "min_x": "min_xy.x",
-            "min_y": "min_xy.y",
-            "max": "max_value",
-            "max_x": "max_xy.x",
-            "max_y": "max_xy.y",
-            "mean": "mean_value",
-            "total": "total",
-            "net": "net",
-            "sigma": "sigma_readout",
+            "min_value": "ts_min_value",
+            "min_x": "ts_min.x",
+            "min_y": "ts_min.y",
+            "max_value": "ts_max_value",
+            "max_x": "ts_max.x",
+            "max_y": "ts_max.y",
+            "mean_value": "ts_mean_value",
+            "sigma": "ts_sigma",
+            "total": "ts_total",
+            "net": "ts_net",
+            "timestamp": "ts_timestamp",
         },
     },
     "centroid": {
         "enable_signal": "compute_centroid",
         "scalar_outputs": [
-            "centroid_total",
             "centroid_x",
             "centroid_y",
             "sigma_x",
@@ -92,74 +143,48 @@ NDPLUGIN_STATS_CONFIG: LITERAL_ROI_PROCESSING_CONFIG = {
         ],
         "waveform_outputs": [],
         "source_signals": {
-            "centroid_total": "centroid_total",
-            "centroid_x": "centroid.x",
-            "centroid_y": "centroid.y",
-            "sigma_x": "sigma_x",
-            "sigma_y": "sigma_y",
-            "sigma_xy": "sigma_xy",
-            "skew_x": "skew.x",
-            "skew_y": "skew.y",
-            "kurtosis_x": "kurtosis.x",
-            "kurtosis_y": "kurtosis.y",
-            "eccentricity": "eccentricity",
-            "orientation": "orientation",
-        },
-    },
-    "profiles": {
-        "enable_signal": "compute_profiles",
-        "scalar_outputs": ["profile_size_x", "profile_size_y", "cursor_x", "cursor_y"],
-        "waveform_outputs": [
-            "profile_average_x",
-            "profile_average_y",
-            "profile_threshold_x",
-            "profile_threshold_y",
-            "profile_centroid_x",
-            "profile_centroid_y",
-            "profile_cursor_x",
-            "profile_cursor_y",
-        ],
-        "source_signals": {
-            "profile_size_x": "profile_size.x",
-            "profile_size_y": "profile_size.y",
-            "cursor_x": "cursor.x",
-            "cursor_y": "cursor.y",
-            "profile_average_x": "profile_average.x",
-            "profile_average_y": "profile_average.y",
-            "profile_threshold_x": "profile_threshold.x",
-            "profile_threshold_y": "profile_threshold.y",
-            "profile_centroid_x": "profile_centroid.x",
-            "profile_centroid_y": "profile_centroid.y",
-            "profile_cursor_x": "profile_cursor.x",
-            "profile_cursor_y": "profile_cursor.y",
-        },
-    },
-    "histogram": {
-        "enable_signal": "compute_histogram",
-        "scalar_outputs": ["hist_below", "hist_above", "hist_entropy"],
-        "waveform_outputs": ["histogram", "histogram_x"],
-        "source_signals": {
-            "hist_below": "hist_below",
-            "hist_above": "hist_above",
-            "hist_entropy": "hist_entropy",
-            "histogram": "histogram",
-            "histogram_x": "histogram_x",
+            "centroid_x": "ts_centroid.x",
+            "centroid_y": "ts_centroid.y",
+            "sigma_x": "ts_sigma_x.ts_sigma_x",
+            "sigma_y": "ts_sigma_x.ts_sigma_y",
+            "sigma_xy": "ts_sigma_xy",
+            "skew_x": "ts_skew.x",
+            "skew_y": "ts_skew.y",
+            "kurtosis_x": "ts_kurtosis.x",
+            "kurtosis_y": "ts_kurtosis.y",
+            "eccentricity": "ts_eccentricity",
+            "orientation": "ts_orientation",
+            "timestamp": "ts_timestamp",
         },
     },
 }
+
+
+class AverageFramesForEachTrigger(Signal):
+    """Signal to compute the average number of frames per trigger."""
+
+    def put(self, value, **kwargs):
+        if not isinstance(value, (bool, int, float)):
+            raise ValueError("average_frames_per_trigger must be a boolean or numeric value.")
+        value = bool(value)
+        super().put(value, **kwargs)
 
 
 class ADROIProcessing(ROIProcessing):
     """ROI processing signal for AD detector setups at PSI."""
 
     roi1 = Cpt(ROIPlugin, "ROI1:", kind="normal")
-    stats1 = Cpt(StatsPlugin, "Stats1:", kind="normal")
+    stats1 = Cpt(StatsPluginWithTSControl, "Stats1:", kind="normal")
+    average_frames_per_trigger = Cpt(
+        AverageFramesForEachTrigger, "average_frames_per_trigger", kind=Kind.config, value=True
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._stats_subscriptions: dict[str, StatsSubscription] = {}
         self._missing_stats_paths: set[str] = set()
         self._config_update_in_progress = False
+        self.scan_server_scan_info: ScanServerScanInfo | None = None
 
     def get_scalar_outputs(self) -> list[str]:
         scalar_outputs = []
@@ -179,7 +204,7 @@ class ADROIProcessing(ROIProcessing):
     def wait_for_connection(self, *args, **kwargs):
         super().wait_for_connection(*args, **kwargs)
         # Subscribe stats plugin to ROI plugin,  the self.root.cam assumes cam to be available on root object, so we trust roi1 to be properly configured.
-        # self.roi1.nd_array_port.put(self.root.cam.port_name.get())
+        self.roi1.nd_array_port.put(self.root.cam.port_name.get())
         self.stats1.nd_array_port.put(self.roi1.port_name.get())
         # ROIPlugin related callbacks
         self.selected_operations.subscribe(
@@ -189,10 +214,6 @@ class ADROIProcessing(ROIProcessing):
         )
         self._apply_roi_configuration()
         self._sync_stats_subscriptions()
-
-    def destroy(self):
-        self._unsubscribe_all_stats()
-        super().destroy()
 
     def _on_config_update(self, value, **kwargs):
         self._config_update_in_progress = True
@@ -215,6 +236,36 @@ class ADROIProcessing(ROIProcessing):
         self.roi1.min_xyz.min_y.put(int(self.y.get()))
         self.roi1.size.x.put(int(self.width.get()))
         self.roi1.size.y.put(int(self.height.get()))
+
+    def _desired_stats_outputs(
+        self,
+    ) -> dict[str, tuple[str, str, Literal["scalar", "waveform"], str]]:
+        """Determine the desired StatsPlugin outputs based on the selected operations."""
+        desired = {}
+        for operation in self.selected_operations.get():
+            config = NDPLUGIN_STATS_CONFIG.get(operation)
+            if not config:
+                continue
+            source_signals = config.get("source_signals", {})
+            for result_name in config.get("scalar_outputs", []):
+                dotted_name = source_signals.get(result_name)
+                if dotted_name:
+                    key = f"{operation}.{result_name}"
+                    desired[key] = (operation, result_name, "scalar", dotted_name)
+            for result_name in config.get("waveform_outputs", []):
+                dotted_name = source_signals.get(result_name)
+                if dotted_name:
+                    key = f"{operation}.{result_name}"
+                    desired[key] = (operation, result_name, "waveform", dotted_name)
+        return desired
+
+    def _resolve_stats_signal(self, dotted_name: str) -> Any:
+        """Resolve a dotted name to an actual signal on the stats1 plugin."""
+        signal = rgetattr(self.stats1, dotted_name, None)
+        if signal is None:
+            logger.warning(f"Could not resolve StatsPlugin signal: {dotted_name}")
+            self._missing_stats_paths.add(dotted_name)
+        return signal
 
     def _sync_stats_subscriptions(self) -> None:
         """Subscribe to selected StatsPlugin outputs and unsubscribe stale ones."""
@@ -253,36 +304,6 @@ class ADROIProcessing(ROIProcessing):
 
         self._apply_stats_enable_signals()
 
-    def _desired_stats_outputs(
-        self,
-    ) -> dict[str, tuple[str, str, Literal["scalar", "waveform"], str]]:
-        if not self.active.get():
-            return {}
-
-        selected_operations = set(self.selected_operations.get())
-        desired = {}
-        for operation, config in NDPLUGIN_STATS_CONFIG.items():
-            if operation not in selected_operations:
-                continue
-            source_signals = config.get("source_signals", {})
-            for result_name in config.get("scalar_outputs", []):
-                signal_path = source_signals[result_name]
-                desired[f"scalar:{operation}:{result_name}"] = (
-                    operation,
-                    result_name,
-                    "scalar",
-                    signal_path,
-                )
-            for result_name in config.get("waveform_outputs", []):
-                signal_path = source_signals[result_name]
-                desired[f"waveform:{operation}:{result_name}"] = (
-                    operation,
-                    result_name,
-                    "waveform",
-                    signal_path,
-                )
-        return desired
-
     def _unsubscribe_all_stats(self) -> None:
         for subscription in self._stats_subscriptions.values():
             subscription.signal.unsubscribe(subscription.callback_id)
@@ -294,25 +315,10 @@ class ADROIProcessing(ROIProcessing):
             enable_signal = config.get("enable_signal")
             if enable_signal is None:
                 continue
-            signal = self._resolve_stats_signal(enable_signal)
+            signal = rgetattr(self.stats1, enable_signal, None)  # Check if the attribute exists
             if signal is None:
                 continue
             signal.put("Yes" if operation in selected_operations else "No")
-
-    def _resolve_stats_signal(self, signal_path: str):
-        """Resolve a dotted StatsPlugin attribute path to an ophyd signal."""
-        try:
-            signal = rgetattr(self.stats1, signal_path)  # Check if the attribute exists
-        except AttributeError:
-            if signal_path not in self._missing_stats_paths:
-                logger.warning(
-                    "StatsPlugin signal path %s is not available on %s.",
-                    signal_path,
-                    self.stats1.__class__.__name__,
-                )
-                self._missing_stats_paths.add(signal_path)
-            return None
-        return signal
 
     def _on_stats_signal_update(
         self,
@@ -325,15 +331,57 @@ class ADROIProcessing(ROIProcessing):
         **kwargs,
     ) -> None:
         """Publish a StatsPlugin update into the matching BEC result signal."""
-        logger.info(f"StatsPlugin update for {operation}.{result_name} ({output_kind}): {value}")
         if not self._is_operation_active(operation):
             return
+        if self.average_frames_per_trigger.get() is True:
+            if isinstance(value, (list, np.ndarray)):
+                value = value / len(value)  # Average over the number of frames per trigger
+            value = float(value)  # Ensure the value is a float for list and np.ndarray types
 
         signal = self.result_scalar if output_kind == "scalar" else self.result_waveform
-        signal.put({result_name: {"value": value, "timestamp": timestamp or self._get_timestamp()}})
+        signal.put({result_name: {"value": value, "timestamp": timestamp or time.time()}})
 
     def _is_operation_active(self, operation: str) -> bool:
         return bool(self.active.get()) and operation in self.selected_operations.get()
+
+    ################
+    ## Scan Hooks ##
+    ################
+
+    def on_connected(self):
+        """Hook called when the device is connected."""
+        # TODO Consider using 'set' in future after wrapping EpicsSignal with proper set wrapper
+        self.stats1.ts_acquire_mode.put(TSAcquireMode.FIXED_LENGTH.value)
+        self.stats1.ts_read_mode.put(TSReadMode.PASSIVE.value)
+        if self.stats1.ts_acquire_status.get() == 0:
+            self.stats1.ts_acquire.put(0)  # Start timestamp acquisition
+
+    def on_stage(self):
+        """Hook called when the device is staged."""
+        self.root: PSIDeviceBase
+        self.scan_server_scan_info = fetch_scan_info(self.root.scan_info)
+        self.stats1.ts_num_points.put(self.scan_server_scan_info.frames_per_trigger)
+
+    def on_trigger(self) -> TransitionStatus:
+        """Hook called when the device is triggered."""
+        # TODO add hook, needs to be triggered before the detector acquire starts if it is triggered manually.
+        status = TransitionStatus(self.stats1.ts_acquire_status, transitions=[1, 0])
+        self.stats1.ts_acquire.put(1)  # Start timestamp acquisition
+        return status
+
+    def on_stop(self):
+        """Hook called when the device is stopped."""
+        self.stats1.ts_acquire.put(0)  # Stop timestamp acquisition
+
+    def on_destroy(self):
+        """Hook called when the device is destroyed."""
+        self.stats1.ts_acquire.put(0)  # Stop timestamp acquisition
+        self._unsubscribe_all_stats()
+
+
+#####################
+### Test Detector ###
+#####################
 
 
 import threading
@@ -426,8 +474,21 @@ class MyDetector(PSIDeviceBase, ADBase):
                     f"Error while polling array data for preview of {self.name}: {content}"
                 )
 
+    def on_stage(self):
+        """Stage the detector and prepare for acquisition."""
+        self.roi_processing.on_stage()  # Stage the ROI processing
+
+    def on_trigger(self):
+        """Trigger the detector and wait for completion."""
+        self.roi_processing.on_trigger()  # Start timestamp acquisition
+
+    def on_stop(self):
+        """Stop the detector and timestamp acquisition."""
+        self.roi_processing.on_stop()  # Stop timestamp acquisition
+
     def on_destroy(self):
         """Clean up resources."""
+        self.roi_processing.on_destroy()  # Stop timestamp acquisition
         self._poll_thread_kill_event.set()
         if self._poll_thread.is_alive():
             self._poll_thread.join(timeout=0.5)

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -317,12 +317,12 @@ import traceback
 
 from ophyd import ADBase
 
-from ophyd_devices import PreviewSignal
+from ophyd_devices import PreviewSignal, PSIDeviceBase
 from ophyd_devices.devices.areadetector.cam import SimDetectorCam
 from ophyd_devices.devices.areadetector.plugins import ImagePlugin_V35 as ImagePlugin
 
 
-class MyDetector(ADBase):
+class MyDetector(PSIDeviceBase, ADBase):
     cam = Cpt(SimDetectorCam, "cam1:")
     image = Cpt(ImagePlugin, "image1:")
     roi_processing = Cpt(ADROIProcessing, prefix="ROI1:", kind="normal")

--- a/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
+++ b/ophyd_devices/utils/bec_roi_signals/ad_roi_signal.py
@@ -153,7 +153,7 @@ class ADROIProcessing(ROIProcessing):
     """ROI processing signal for AD detector setups at PSI."""
 
     roi1 = Cpt(ROIPlugin, "ROI1:", kind="normal")
-    stats1 = Cpt(StatsPlugin, "STATS1:", kind="normal")
+    stats1 = Cpt(StatsPlugin, "Stats1:", kind="normal")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ophyd_devices/utils/bec_roi_signals/roi_processing.py
+++ b/ophyd_devices/utils/bec_roi_signals/roi_processing.py
@@ -8,8 +8,7 @@ from bec_lib.logger import bec_logger
 from bec_lib.messages import ROIAnalysisConfig, ROIAvailableAnalysisMessage, ROIConfigurationMessage
 from bec_lib.redis_connector import RedisConnector
 from ophyd import Component as Cpt
-from ophyd import Device, Signal, SignalRO
-from ophyd.device import required_for_connection
+from ophyd import Device, Kind, Signal
 
 from ophyd_devices.utils.bec_roi_signals.signals import (
     AvailableOperationsSignal,
@@ -40,6 +39,7 @@ class ROIProcessing(Device, ABC):
         signals=[],
         ndim=0,
         async_update={"type": "add", "max_shape": [None]},
+        data_type="processed",
     )
     result_waveform = Cpt(
         DynamicSignal,
@@ -48,44 +48,59 @@ class ROIProcessing(Device, ABC):
         signals=[],
         ndim=1,
         async_update={"type": "add", "max_shape": [None, None]},
+        data_type="processed",
     )
 
-    active = Cpt(Signal, value=False, kind="config")
-    roi_name = Cpt(Signal, value="roi", kind="config")
-    x = Cpt(Signal, value=0, kind="config")
-    y = Cpt(Signal, value=0, kind="config")
-    width = Cpt(Signal, value=10, kind="config")
-    height = Cpt(Signal, value=10, kind="config")
-    selected_operations = Cpt(SelectedOperationSignal, value=[], kind="config")
-    available_operations = Cpt(AvailableOperationsSignal, kind="config")
-    update_received = Cpt(ConfigUpdateReceivedSignal, kind="omitted")
+    active = Cpt(Signal, value=False, kind=Kind.normal)
+    roi_name = Cpt(Signal, value="roi", kind=Kind.normal)
+    x = Cpt(Signal, value=0, kind=Kind.normal)
+    y = Cpt(Signal, value=0, kind=Kind.normal)
+    width = Cpt(Signal, value=0, kind=Kind.normal)
+    height = Cpt(Signal, value=0, kind=Kind.normal)
+    selected_operations = Cpt(SelectedOperationSignal, value=[], kind=Kind.normal)
+    available_operations = Cpt(AvailableOperationsSignal, kind=Kind.config)
+    update_received = Cpt(ConfigUpdateReceivedSignal, kind=Kind.omitted)
 
     def __init__(self, *args, **kwargs):
         kwargs, signal_kwargs = self._get_kwargs_for_signals(kwargs)
         super().__init__(*args, **kwargs)
         self._signal_kwargs = signal_kwargs
         self._connector: RedisConnector | None = None
-        # Setup the DynamicSignal outputs based on the available operations and outputs
-        self._prepare_result_signals()
+        self._update_result_signal_names()
 
-    def _prepare_result_signals(self):
-        """Prepare the result signals based on the available operations and outputs."""
+    def _update_result_signal_names(self):
+        """
+        Update the signal names for the DynamicSignals "result_scalar" and "result_waveform" based on
+        the outputs defined in the subclass. This ensures that the signals.
+        Subclasses must specify every possible output signal in the get_scalar_outputs and get_waveform_outputs methods.
+        """
+        # pylint: disable=protected-access
         self.result_scalar.signals = self.result_scalar._unify_signals(self.get_scalar_outputs())
         self.result_waveform.signals = self.result_waveform._unify_signals(
             self.get_waveform_outputs()
         )
 
     def _get_kwargs_for_signals(self, kwargs) -> tuple[dict, dict[str, dict]]:
-        """Get the kwargs for the signals of this device."""
+        """
+        Utility method to extract kwargs for the signals defined in this class.
+        This allows to set initial values for the signals during initialization of the ROIProcessing device.
+        """
         ret_kwargs = {}
         for k in ["active", "roi_name", "x", "y", "width", "height", "selected_operations"]:
             if k in kwargs:
                 ret_kwargs[k] = kwargs.pop(k)
         return kwargs, ret_kwargs
 
-    @required_for_connection
     def wait_for_connection(self, all_signals=False, timeout=...):
-        """Wait for the ROI processing signal to be connected to Redis."""
+        """
+        Wait for the ROI processing signal to be connected to Redis. The root device must ensure
+        that wait_for_connection is called when connecting the device. Otherwise, the ROIProcessing
+        component will not work properly.
+
+        The root device also needs a device_manager and a RedisConnector available.
+        Please use PSIDeviceBase as a base class for your root device to ensure this is the case.
+        -> ophyd_devices.interfaces.base_classes.psi_device_base.PSIDeviceBase
+        """
         self._connector: RedisConnector | None = (
             self.root.device_manager.connector if hasattr(self.root, "device_manager") else None
         )
@@ -94,7 +109,7 @@ class ROIProcessing(Device, ABC):
                 f"Signal {self.name} is not connected to Redis, please provide a Redis Connector during the initialization."
             )
         super().wait_for_connection(all_signals, timeout)
-        # Set initial values for the configuration signals from the kwargs provided during initialization
+        # Setup initial values for the signal as provided in the kwargs during initialization
         for signal_name, value in self._signal_kwargs.items():
             signal = getattr(self, signal_name)
             signal.put(value)
@@ -104,38 +119,40 @@ class ROIProcessing(Device, ABC):
             self._on_config_update, event_type=self.update_received.SUB_VALUE, run=False
         )
         self._connector.register(
-            MessageEndpoints.roi_config(device=self.root.name, signal=self.endpoint_signal_name),
-            cb=self.receive_roi_configuration_message,
+            MessageEndpoints.roi_config(device=self.root.name, signal=self.dotted_name),
+            cb=self._receive_roi_configuration_message,
         )
-        self.publish_available_analysis()
+        self._publish_available_analysis()
 
     def destroy(self):
         """Clean up the ROI processing signal and unregister from Redis."""
         if self._connector is not None:
             self._connector.unregister(
-                MessageEndpoints.roi_config(
-                    device=self.root.name, signal=self.endpoint_signal_name
-                ),
-                cb=self.receive_roi_configuration_message,
+                MessageEndpoints.roi_config(device=self.root.name, signal=self.dotted_name),
+                cb=self._receive_roi_configuration_message,
             )
         super().destroy()
 
     @abstractmethod
     def get_scalar_outputs(self) -> list[str]:
-        """Return the scalar output signal for the ROI processing signal."""
+        """
+        Returns a list of strings with all possible scalar output signals for the ROI processing signal.
+        All possible outputs must be listed, although not all of them have to be there at the same time.
+        """
 
     @abstractmethod
     def get_waveform_outputs(self) -> list[str]:
-        """Return the waveform output signal for the ROI processing signal."""
+        """
+        Returns a list of strings with all possible waveform output signals for the ROI processing signal.
+        All possible outputs must be listed, although not all of them have to be there at the same time.
+        """
 
     @abstractmethod
     def get_available_analysis_operations(self) -> list[str]:
-        """Return the available analysis operations for the ROI processing signal."""
-
-    @property
-    def endpoint_signal_name(self) -> str:
-        """Return the component signal name used for BEC ROI endpoints."""
-        return getattr(self, "dotted_name", None) or getattr(self, "attr_name", None) or self.name
+        """
+        Returns a list of strings with all possible analysis operations for the ROI processing signal.
+        All possible operations must be listed, although not all of them have to be active at the same time.
+        """
 
     def compile_roi_analysis_config(self) -> ROIAnalysisConfig:
         """Compile the ROI analysis configuration from the available operations and outputs."""
@@ -145,7 +162,7 @@ class ROIProcessing(Device, ABC):
             scalar_results=self.get_scalar_outputs(),
         )
 
-    def publish_available_analysis(self) -> None:
+    def _publish_available_analysis(self) -> None:
         """Publish the available ROI analysis operations and result signals."""
         if self._connector is None:
             raise RuntimeError(
@@ -153,29 +170,37 @@ class ROIProcessing(Device, ABC):
             )
         message = ROIAvailableAnalysisMessage(
             device=self.root.name,
-            signal=self.endpoint_signal_name,
+            signal=self.dotted_name,
             config=self.compile_roi_analysis_config(),
         )
         self._connector.set_and_publish(
-            MessageEndpoints.available_roi_analysis(
-                device=self.root.name, signal=self.endpoint_signal_name
-            ),
+            MessageEndpoints.available_roi_analysis(device=self.root.name, signal=self.dotted_name),
             message,
         )
 
-    def receive_roi_configuration_message(self, message: MessageObject):
-        """Receive a ROI configuration message and update the ROI processing signal accordingly."""
+    def _receive_roi_configuration_message(self, message: MessageObject):
+        """
+        Receive a ROI configuration message and update the ROI processing signal accordingly.
+
+        Args:
+            message (MessageObject): The received message object containing the ROI configuration.
+        """
         message: ROIConfigurationMessage = message.value
-        if message.device != self.root.name or message.signal != self.endpoint_signal_name:
+        if message.device != self.root.name or message.signal != self.dotted_name:
             logger.warning(
                 f"Ignoring ROI configuration for {message.device}.{message.signal}; "
-                f"this ROIProcessing is {self.root.name}.{self.endpoint_signal_name}."
+                f"this ROIProcessing is {self.root.name}.{self.dotted_name}."
             )
             return
         self.update_received.put(message)
 
-    def _on_config_update(self, value, **kwargs):
-        """Callback for when a new ROI configuration message is received."""
+    def _on_config_update(self, value: ROIConfigurationMessage, **kwargs):
+        """
+        Callback for when a new ROI configuration message is received.
+
+        Args:
+            value (ROIConfigurationMessage): The received ROI configuration message.
+        """
         if not isinstance(value, ROIConfigurationMessage):
             raise TypeError(
                 f"Expected ROIConfigurationMessage, got {type(value).__name__} instead."

--- a/ophyd_devices/utils/bec_roi_signals/roi_processing.py
+++ b/ophyd_devices/utils/bec_roi_signals/roi_processing.py
@@ -131,6 +131,21 @@ class ROIProcessing(Device, ABC):
             cb=self._receive_roi_configuration_message,
         )
         self._publish_available_analysis()
+        if self.active.get():
+            msg = ROIConfigurationMessage(
+                device=self.root.name,
+                signal=self.dotted_name,
+                active=self.active.get(),
+                name=self.roi_name.get(),
+                roi_config={
+                    "x": self.x.get(),
+                    "y": self.y.get(),
+                    "width": self.width.get(),
+                    "height": self.height.get(),
+                },
+                selected_operations=self.selected_operations.get(),
+            )
+            self._on_config_update(msg)  # Apply the initial configuration if active is True
 
     def destroy(self):
         """Clean up the ROI processing signal and unregister from Redis."""

--- a/ophyd_devices/utils/bec_roi_signals/roi_processing.py
+++ b/ophyd_devices/utils/bec_roi_signals/roi_processing.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Literal
+
+from bec_lib.endpoints import MessageEndpoints
+from bec_lib.logger import bec_logger
+from bec_lib.messages import ROIAnalysisConfig, ROIAvailableAnalysisMessage, ROIConfigurationMessage
+from bec_lib.redis_connector import RedisConnector
+from ophyd import Component as Cpt
+from ophyd import Device, Signal, SignalRO
+from ophyd.device import required_for_connection
+
+from ophyd_devices.utils.bec_roi_signals.signals import (
+    AvailableOperationsSignal,
+    ConfigUpdateReceivedSignal,
+    SelectedOperationSignal,
+)
+from ophyd_devices.utils.bec_signals import DynamicSignal
+
+if TYPE_CHECKING:
+    from bec_lib.connector import MessageObject
+
+logger = bec_logger.logger
+
+LITERAL_ROI_PROCESSING_CONFIG = dict[
+    str, dict[Literal["scalar_outputs", "waveform_outputs"], list[str]]
+]
+
+
+class ROIProcessing(Device, ABC):
+    """Abstract base class for ROI processing signals"""
+
+    REQUIRES_WAIT_FOR_CONNECTION = True
+
+    result_scalar = Cpt(
+        DynamicSignal,
+        name="result_scalar",
+        max_size=1000,
+        signals=[],
+        ndim=0,
+        async_update={"type": "add", "max_shape": [None]},
+    )
+    result_waveform = Cpt(
+        DynamicSignal,
+        name="result_waveform",
+        max_size=1000,
+        signals=[],
+        ndim=1,
+        async_update={"type": "add", "max_shape": [None, None]},
+    )
+
+    active = Cpt(Signal, value=False, kind="config")
+    roi_name = Cpt(Signal, value="roi", kind="config")
+    x = Cpt(Signal, value=0, kind="config")
+    y = Cpt(Signal, value=0, kind="config")
+    width = Cpt(Signal, value=10, kind="config")
+    height = Cpt(Signal, value=10, kind="config")
+    selected_operations = Cpt(SelectedOperationSignal, value=[], kind="config")
+    available_operations = Cpt(AvailableOperationsSignal, kind="config")
+    update_received = Cpt(ConfigUpdateReceivedSignal, kind="omitted")
+
+    def __init__(self, *args, **kwargs):
+        kwargs, signal_kwargs = self._get_kwargs_for_signals(kwargs)
+        super().__init__(*args, **kwargs)
+        self._signal_kwargs = signal_kwargs
+        self._connector: RedisConnector | None = None
+        # Setup the DynamicSignal outputs based on the available operations and outputs
+        self._prepare_result_signals()
+
+    def _prepare_result_signals(self):
+        """Prepare the result signals based on the available operations and outputs."""
+        self.result_scalar.signals = self.result_scalar._unify_signals(self.get_scalar_outputs())
+        self.result_waveform.signals = self.result_waveform._unify_signals(
+            self.get_waveform_outputs()
+        )
+
+    def _get_kwargs_for_signals(self, kwargs) -> tuple[dict, dict[str, dict]]:
+        """Get the kwargs for the signals of this device."""
+        ret_kwargs = {}
+        for k in ["active", "roi_name", "x", "y", "width", "height", "selected_operations"]:
+            if k in kwargs:
+                ret_kwargs[k] = kwargs.pop(k)
+        return kwargs, ret_kwargs
+
+    @required_for_connection
+    def wait_for_connection(self, all_signals=False, timeout=...):
+        """Wait for the ROI processing signal to be connected to Redis."""
+        self._connector: RedisConnector | None = (
+            self.root.device_manager.connector if hasattr(self.root, "device_manager") else None
+        )
+        if self._connector is None:
+            raise RuntimeError(
+                f"Signal {self.name} is not connected to Redis, please provide a Redis Connector during the initialization."
+            )
+        super().wait_for_connection(all_signals, timeout)
+        # Set initial values for the configuration signals from the kwargs provided during initialization
+        for signal_name, value in self._signal_kwargs.items():
+            signal = getattr(self, signal_name)
+            signal.put(value)
+
+        # Connect to relevant endpoint for ROI configuration updates
+        self.update_received.subscribe(
+            self._on_config_update, event_type=self.update_received.SUB_VALUE, run=False
+        )
+        self._connector.register(
+            MessageEndpoints.roi_config(device=self.root.name, signal=self.endpoint_signal_name),
+            cb=self.receive_roi_configuration_message,
+        )
+        self.publish_available_analysis()
+
+    def destroy(self):
+        """Clean up the ROI processing signal and unregister from Redis."""
+        if self._connector is not None:
+            self._connector.unregister(
+                MessageEndpoints.roi_config(
+                    device=self.root.name, signal=self.endpoint_signal_name
+                ),
+                cb=self.receive_roi_configuration_message,
+            )
+        super().destroy()
+
+    @abstractmethod
+    def get_scalar_outputs(self) -> list[str]:
+        """Return the scalar output signal for the ROI processing signal."""
+
+    @abstractmethod
+    def get_waveform_outputs(self) -> list[str]:
+        """Return the waveform output signal for the ROI processing signal."""
+
+    @abstractmethod
+    def get_available_analysis_operations(self) -> list[str]:
+        """Return the available analysis operations for the ROI processing signal."""
+
+    @property
+    def endpoint_signal_name(self) -> str:
+        """Return the component signal name used for BEC ROI endpoints."""
+        return getattr(self, "dotted_name", None) or getattr(self, "attr_name", None) or self.name
+
+    def compile_roi_analysis_config(self) -> ROIAnalysisConfig:
+        """Compile the ROI analysis configuration from the available operations and outputs."""
+        return ROIAnalysisConfig(
+            available_operations=self.get_available_analysis_operations(),
+            waveform_results=self.get_waveform_outputs(),
+            scalar_results=self.get_scalar_outputs(),
+        )
+
+    def publish_available_analysis(self) -> None:
+        """Publish the available ROI analysis operations and result signals."""
+        if self._connector is None:
+            raise RuntimeError(
+                f"Signal {self.name} is not connected to Redis and cannot publish ROI analysis."
+            )
+        message = ROIAvailableAnalysisMessage(
+            device=self.root.name,
+            signal=self.endpoint_signal_name,
+            config=self.compile_roi_analysis_config(),
+        )
+        self._connector.set_and_publish(
+            MessageEndpoints.available_roi_analysis(
+                device=self.root.name, signal=self.endpoint_signal_name
+            ),
+            message,
+        )
+
+    def receive_roi_configuration_message(self, message: MessageObject):
+        """Receive a ROI configuration message and update the ROI processing signal accordingly."""
+        message: ROIConfigurationMessage = message.value
+        if message.device != self.root.name or message.signal != self.endpoint_signal_name:
+            logger.warning(
+                f"Ignoring ROI configuration for {message.device}.{message.signal}; "
+                f"this ROIProcessing is {self.root.name}.{self.endpoint_signal_name}."
+            )
+            return
+        self.update_received.put(message)
+
+    def _on_config_update(self, value, **kwargs):
+        """Callback for when a new ROI configuration message is received."""
+        if not isinstance(value, ROIConfigurationMessage):
+            raise TypeError(
+                f"Expected ROIConfigurationMessage, got {type(value).__name__} instead."
+            )
+        self.active.put(value.active)
+        self.roi_name.put(value.name)
+        self.x.put(value.roi_config.x)
+        self.y.put(value.roi_config.y)
+        self.width.put(value.roi_config.width)
+        self.height.put(value.roi_config.height)
+        self.selected_operations.put(value.selected_operations)

--- a/ophyd_devices/utils/bec_roi_signals/roi_processing.py
+++ b/ophyd_devices/utils/bec_roi_signals/roi_processing.py
@@ -91,7 +91,7 @@ class ROIProcessing(Device, ABC):
                 ret_kwargs[k] = kwargs.pop(k)
         return kwargs, ret_kwargs
 
-    def wait_for_connection(self, all_signals=False, timeout=...):
+    def wait_for_connection(self, all_signals=False, timeout=5):
         """
         Wait for the ROI processing signal to be connected to Redis. The root device must ensure
         that wait_for_connection is called when connecting the device. Otherwise, the ROIProcessing

--- a/ophyd_devices/utils/bec_roi_signals/roi_processing.py
+++ b/ophyd_devices/utils/bec_roi_signals/roi_processing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, TypedDict
 
 from bec_lib.endpoints import MessageEndpoints
 from bec_lib.logger import bec_logger
@@ -22,9 +22,17 @@ if TYPE_CHECKING:
 
 logger = bec_logger.logger
 
-LITERAL_ROI_PROCESSING_CONFIG = dict[
-    str, dict[Literal["scalar_outputs", "waveform_outputs"], list[str]]
-]
+
+class ROIOperationConfig(TypedDict, total=False):
+    """Configuration for one selectable ROI analysis operation."""
+
+    scalar_outputs: list[str]
+    waveform_outputs: list[str]
+    enable_signal: str | None
+    source_signals: dict[str, str]
+
+
+LITERAL_ROI_PROCESSING_CONFIG = dict[str, ROIOperationConfig]
 
 
 class ROIProcessing(Device, ABC):

--- a/ophyd_devices/utils/bec_roi_signals/signals.py
+++ b/ophyd_devices/utils/bec_roi_signals/signals.py
@@ -45,7 +45,10 @@ class AvailableOperationsSignal(SignalRO):
 
 
 class ConfigUpdateReceivedSignal(Signal):
-    """Signal to publish ROI configuration updates, optionally coalescing them while blocked."""
+    """
+    Signal to publish ROI configuration updates. Based on the updated configuration,
+    updates will be published right away or blocked until released.
+    """
 
     def __init__(self, name, parent=None, **kwargs):
         super().__init__(name=name, parent=parent, **kwargs)
@@ -74,16 +77,20 @@ class ConfigUpdateReceivedSignal(Signal):
 
     def destroy(self):
         """Clean up the signal and unregister from Redis."""
-        if self._connector is not None:
+        if self._connector is not None and self._metadata.get("connected") is True:
             self._connector.unregister(
                 MessageEndpoints.scan_status(), self._handle_scan_status_update
             )
+        self._metadata["connected"] = False
         super().destroy()
 
     @property
     def connected(self) -> bool:
         """Return whether the signal is connected to Redis."""
-        self.wait_for_connection()
+        if self._destroyed:
+            return False
+        if self._metadata.get("connected") is not True:
+            self.wait_for_connection()
         return self._metadata.get("connected", False)
 
     def wait_for_connection(self, *args, **kwargs):
@@ -143,7 +150,14 @@ class ConfigUpdateReceivedSignal(Signal):
         timeout=None,
         **kwargs,
     ):
-        """Publish ``value`` immediately, or stage it as the next update while blocked."""
+        """
+        Put a new ROI configuration message to the signal. If updates are currently blocked,
+        the update will be cached and published once `unblock_updates` is called. Any subsequent
+        updates will overwrite the cached update until updates are unblocked.
+
+        Args:
+            value (ROIConfigurationMessage): The new ROI configuration message to put.
+        """
         if self._metadata.get("connected") is not True:
             raise RuntimeError(
                 f"Signal {self.name} is not connected to Redis and cannot publish updates."

--- a/ophyd_devices/utils/bec_roi_signals/signals.py
+++ b/ophyd_devices/utils/bec_roi_signals/signals.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+from bec_lib.endpoints import MessageEndpoints
+from bec_lib.logger import bec_logger
+from bec_lib.messages import ROIConfigurationMessage, ScanStatusMessage
+from ophyd import Signal, SignalRO
+from ophyd.status import Status
+
+if TYPE_CHECKING:
+    from bec_lib.redis_connector import MessageObject, RedisConnector
+
+logger = bec_logger.logger
+
+
+class SelectedOperationSignal(Signal):
+    """
+    Signal for selecting ROI analysis operations.
+
+    The parent class must implement ``get_available_analysis_operations()``.
+    """
+
+    def check_value(self, value: list[str], **kwargs):
+        """Check that all selected operations are available."""
+        available_operations = self.parent.get_available_analysis_operations()
+        if not all(v in available_operations for v in value):
+            raise ValueError(
+                f"Invalid operation(s): {value}. Must be one of {available_operations}."
+            )
+        return value
+
+
+class AvailableOperationsSignal(SignalRO):
+    """
+    Signal for providing the available ROI analysis operations.
+
+    The parent class must implement ``get_available_analysis_operations()``.
+    """
+
+    def get(self, **kwargs):
+        """Return the list of available operations."""
+        return self.parent.get_available_analysis_operations()
+
+
+class ConfigUpdateReceivedSignal(Signal):
+    """Signal to publish ROI configuration updates, optionally coalescing them while blocked."""
+
+    def __init__(self, name, parent=None, **kwargs):
+        super().__init__(name=name, parent=parent, **kwargs)
+        self._update_received = False
+        self._connector: RedisConnector | None = None
+        self._metadata["connected"] = False
+        self._next_config = None
+        self._next_config_kwargs = None
+        self._updates_blocked = False
+        self._update_lock = threading.RLock()
+
+    @property
+    def updates_blocked(self) -> bool:
+        """Return whether incoming updates are currently held back."""
+        return self._updates_blocked
+
+    @property
+    def has_pending_update(self) -> bool:
+        """Return whether a blocked update is waiting to be published."""
+        return self._update_received
+
+    @property
+    def next_config(self):
+        """Return the latest blocked update without publishing it."""
+        return self._next_config
+
+    def destroy(self):
+        """Clean up the signal and unregister from Redis."""
+        if self._connector is not None:
+            self._connector.unregister(
+                MessageEndpoints.scan_status(), self._handle_scan_status_update
+            )
+        super().destroy()
+
+    @property
+    def connected(self) -> bool:
+        """Return whether the signal is connected to Redis."""
+        self.wait_for_connection()
+        return self._metadata.get("connected", False)
+
+    def wait_for_connection(self, *args, **kwargs):
+        self._connector: RedisConnector | None = (
+            self.root.device_manager.connector if hasattr(self.root, "device_manager") else None
+        )
+        if self._connector is None:
+            raise RuntimeError(
+                f"Signal {self.name} is not connected to Redis, please provide a Redis Connector during the initialization."
+            )
+        self._metadata["connected"] = True
+        self._connector.register(MessageEndpoints.scan_status(), cb=self._handle_scan_status_update)
+
+    def _handle_scan_status_update(self, message: MessageObject):
+        msg: ScanStatusMessage = message.value
+        if msg.status == "open":
+            self.block_updates()
+        elif msg.status != "paused":
+            self.unblock_updates()
+
+    def block_updates(self) -> None:
+        """Hold back incoming updates until :meth:`unblock_updates` is called."""
+        with self._update_lock:
+            self._updates_blocked = True
+
+    def unblock_updates(self):
+        """Allow updates again and publish the latest update received while blocked."""
+        with self._update_lock:
+            self._updates_blocked = False
+            if not self._update_received:
+                return None
+
+            value = self._next_config
+            kwargs = self._next_config_kwargs or {}
+            self._next_config = None
+            self._next_config_kwargs = None
+            self._update_received = False
+
+            try:
+                super().put(value, **kwargs)
+            except Exception:
+                self._next_config = value
+                self._next_config_kwargs = dict(
+                    timestamp=None, force=False, metadata=None, timeout=None
+                )
+                self._update_received = True
+                raise
+            return value
+
+    def put(
+        self,
+        value: ROIConfigurationMessage,
+        *,
+        timestamp=None,
+        force=False,
+        metadata=None,
+        timeout=None,
+        **kwargs,
+    ):
+        """Publish ``value`` immediately, or stage it as the next update while blocked."""
+        if self._metadata.get("connected") is not True:
+            raise RuntimeError(
+                f"Signal {self.name} is not connected to Redis and cannot publish updates."
+            )
+        with self._update_lock:
+            self.check_value(value)
+            if value.block_while_scanning is False or not self._updates_blocked:
+                super().put(
+                    value,
+                    timestamp=timestamp,
+                    force=force,
+                    metadata=metadata,
+                    timeout=timeout,
+                    **kwargs,
+                )
+                return
+
+            self._next_config = value
+            self._next_config_kwargs = dict(
+                timestamp=timestamp, force=force, metadata=metadata, timeout=timeout, **kwargs
+            )
+            self._update_received = True
+
+    def set(self, value, *, timeout=None, settle_time=None, **kwargs):
+        """Set the signal value, staging it if updates are currently blocked."""
+        status = Status(self, timeout=timeout, settle_time=settle_time or 0)
+        try:
+            self.put(value, **kwargs)
+        except Exception as exc:
+            status.set_exception(exc)
+        else:
+            status.set_finished()
+        return status
+
+    def check_value(self, value, **kwargs):
+        """Check that the value is a ROI configuration message."""
+        if not isinstance(value, ROIConfigurationMessage):
+            raise ValueError(
+                f"Invalid value: {value}. Must be an instance of ROIConfigurationMessage."
+            )
+        super().check_value(value, **kwargs)

--- a/ophyd_devices/utils/bec_roi_signals/signals.py
+++ b/ophyd_devices/utils/bec_roi_signals/signals.py
@@ -79,7 +79,7 @@ class ConfigUpdateReceivedSignal(Signal):
         """Clean up the signal and unregister from Redis."""
         if self._connector is not None and self._metadata.get("connected") is True:
             self._connector.unregister(
-                MessageEndpoints.scan_status(), self._handle_scan_status_update
+                MessageEndpoints.scan_status(), cb=self._handle_scan_status_update
             )
         self._metadata["connected"] = False
         super().destroy()

--- a/tests/test_roi_processing.py
+++ b/tests/test_roi_processing.py
@@ -1,0 +1,217 @@
+"""Tests for ROI processing signals."""
+
+# pylint: disable=protected-access,redefined-outer-name,too-many-arguments
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from bec_lib import messages
+from bec_server.device_server.tests.utils import DMMock
+
+from ophyd_devices.sim.sim_camera import SimCamera
+
+
+@pytest.fixture(scope="function")
+def camera_with_roi(name="camera"):
+    """Fixture for SimCamera with ROI processing connected."""
+    dm = DMMock()
+    cam = SimCamera(name=name, device_manager=dm)
+    cam.wait_for_connection()
+    yield cam
+    cam.destroy()
+
+
+@pytest.fixture(scope="function")
+def roi_processing(camera_with_roi):
+    """Fixture for the SimCamera ROI processing signal."""
+    yield camera_with_roi.roi_processing
+
+
+def _roi_config_message(
+    *,
+    device="camera",
+    signal="roi_processing",
+    name="roi",
+    active=True,
+    x=0,
+    y=0,
+    width=1,
+    height=1,
+    selected_operations=None,
+    block_while_scanning=True,
+):
+    """Create a ROI configuration message."""
+    return messages.ROIConfigurationMessage(
+        device=device,
+        signal=signal,
+        name=name,
+        active=active,
+        roi_config=messages.ROIConfig(x=x, y=y, width=width, height=height),
+        selected_operations=selected_operations or ["basic_statistics"],
+        block_while_scanning=block_while_scanning,
+    )
+
+
+def _scalar_result_values(roi_processing):
+    """Return scalar ROI results keyed by short result name."""
+    message = roi_processing.result_scalar.get()
+    prefix = f"{roi_processing.result_scalar.name}_"
+    return {
+        signal_name.removeprefix(prefix): data["value"]
+        for signal_name, data in message.signals.items()
+    }
+
+
+def test_sim_camera_roi_processing_initializes_available_analysis(camera_with_roi):
+    """Test that SimCamera exposes the available ROI analysis metadata."""
+    roi = camera_with_roi.roi_processing
+
+    assert roi.get_available_analysis_operations() == ["basic_statistics"]
+    assert roi.available_operations.get() == ["basic_statistics"]
+    assert roi.get_scalar_outputs() == ["sum", "mean", "min", "max"]
+    assert roi.get_waveform_outputs() == []
+    assert [name for name, _ in roi.result_scalar.signals] == ["sum", "mean", "min", "max"]
+    assert roi.result_waveform.signals == []
+
+    published = [
+        item["msg"]
+        for item in camera_with_roi.device_manager.connector.message_sent
+        if isinstance(item["msg"], messages.ROIAvailableAnalysisMessage)
+    ]
+    assert len(published) == 1
+    assert published[0].device == camera_with_roi.name
+    assert published[0].signal == roi.dotted_name
+    assert published[0].config.available_operations == ["basic_statistics"]
+    assert published[0].config.scalar_results == ["sum", "mean", "min", "max"]
+    assert published[0].config.waveform_results == []
+
+
+def test_selected_operations_reject_unknown_operation(roi_processing):
+    """Test that selected operations are validated against the available operations."""
+    with pytest.raises(ValueError, match="Invalid operation"):
+        roi_processing.selected_operations.put(["does_not_exist"])
+
+
+def test_sim_camera_roi_processing_extracts_clipped_roi(roi_processing):
+    """Test that ROI extraction clips negative starts to the image boundary."""
+    image = np.arange(20).reshape(4, 5)
+    roi_processing.x.put(-1)
+    roi_processing.y.put(1)
+    roi_processing.width.put(4)
+    roi_processing.height.put(3)
+
+    np.testing.assert_array_equal(roi_processing._extract_roi(image), image[1:4, 0:3])
+
+
+@pytest.mark.parametrize(
+    "x, y, width, height", [(10, 0, 2, 2), (0, 10, 2, 2), (0, 0, 0, 2), (0, 0, 2, -1)]
+)
+def test_sim_camera_roi_processing_extracts_empty_roi(roi_processing, x, y, width, height):
+    """Test that out-of-bounds or non-positive ROIs produce empty arrays."""
+    roi_processing.x.put(x)
+    roi_processing.y.put(y)
+    roi_processing.width.put(width)
+    roi_processing.height.put(height)
+
+    assert roi_processing._extract_roi(np.ones((4, 5))).size == 0
+
+
+def test_sim_camera_roi_processing_computes_basic_statistics(roi_processing):
+    """Test basic scalar statistics for a ROI image."""
+    stats = roi_processing._compute_basic_statistics(np.array([[1, 2], [3, 4]]))
+
+    assert set(stats) == {"sum", "mean", "min", "max"}
+    assert stats["sum"]["value"] == 10
+    assert stats["mean"]["value"] == 2.5
+    assert stats["min"]["value"] == 1
+    assert stats["max"]["value"] == 4
+    assert all("timestamp" in entry for entry in stats.values())
+
+
+def test_roi_configuration_message_updates_processing_signals(roi_processing):
+    """Test that a received ROI configuration updates all processing signals."""
+    message = _roi_config_message(
+        name="beam",
+        active=False,
+        x=3,
+        y=4,
+        width=5,
+        height=6,
+        selected_operations=["basic_statistics"],
+    )
+
+    roi_processing._receive_roi_configuration_message(SimpleNamespace(value=message))
+
+    assert roi_processing.active.get() is False
+    assert roi_processing.roi_name.get() == "beam"
+    assert roi_processing.x.get() == 3
+    assert roi_processing.y.get() == 4
+    assert roi_processing.width.get() == 5
+    assert roi_processing.height.get() == 6
+    assert roi_processing.selected_operations.get() == ["basic_statistics"]
+
+
+def test_roi_configuration_message_for_other_signal_is_ignored(roi_processing):
+    """Test that ROI configuration messages are scoped to the matching signal."""
+    initial_x = roi_processing.x.get()
+    message = _roi_config_message(signal="other_roi_processing", x=99)
+
+    roi_processing._receive_roi_configuration_message(SimpleNamespace(value=message))
+
+    assert roi_processing.x.get() == initial_x
+
+
+def test_blocked_roi_configuration_updates_apply_latest_on_unblock(roi_processing):
+    """Test that blocked ROI config updates cache and apply only the latest value."""
+    roi_processing.update_received.block_updates()
+    first = _roi_config_message(name="first", x=1)
+    latest = _roi_config_message(name="latest", x=7, width=8)
+
+    roi_processing.update_received.put(first)
+    roi_processing.update_received.put(latest)
+
+    assert roi_processing.update_received.has_pending_update is True
+    assert roi_processing.roi_name.get() != "latest"
+
+    released = roi_processing.update_received.unblock_updates()
+
+    assert released == latest
+    assert roi_processing.update_received.has_pending_update is False
+    assert roi_processing.roi_name.get() == "latest"
+    assert roi_processing.x.get() == 7
+    assert roi_processing.width.get() == 8
+
+
+def test_sim_camera_image_update_publishes_roi_scalar_results(camera_with_roi):
+    """Test SimCamera image updates are processed into ROI scalar results."""
+    camera_with_roi.image_shape.set((6, 6)).wait()
+    camera_with_roi.sim.select_model("constant")
+    camera_with_roi.sim.params = {
+        "amplitude": 5,
+        "noise": "none",
+        "hot_pixel_coords": [],
+        "hot_pixel_types": [],
+        "hot_pixel_values": [],
+    }
+    roi = camera_with_roi.roi_processing
+    roi.active.put(True)
+    roi.selected_operations.put(["basic_statistics"])
+    roi.x.put(1)
+    roi.y.put(2)
+    roi.width.put(3)
+    roi.height.put(2)
+
+    image = camera_with_roi.image.get()
+
+    assert image.shape == (6, 6)
+    assert _scalar_result_values(roi) == {"sum": 30.0, "mean": 5.0, "min": 5.0, "max": 5.0}
+
+
+def test_sim_camera_image_update_does_not_publish_when_roi_inactive(roi_processing):
+    """Test inactive ROI processing ignores image updates."""
+    roi_processing.active.put(False)
+
+    roi_processing._on_image_update(np.ones((3, 3)))
+
+    assert roi_processing.result_scalar.get() is None


### PR DESCRIPTION
# Summary

This PR adds a new abstract base class for ROI signals. It allows subclasses to use the interface, receive updates on ROI objects and forward these parameters to a dedicated backend. This PR introduces this interface for the SIMCamera, and further for the AreaDetector Plugins ROI and STATS. 

Requires branch in BEC to be merged (https://github.com/bec-project/bec/pull/971)

